### PR TITLE
removes columns with no column name in s3 csv from data uploaded to bigquery

### DIFF
--- a/data_pipeline/s3_csv_data/s3_csv_etl.py
+++ b/data_pipeline/s3_csv_data/s3_csv_etl.py
@@ -144,6 +144,7 @@ def get_standardized_csv_header(
     csv_header = record_list[csv_config.header_line_index].split(",")
     standardized_csv_header = [
         standardize_field_name(field.lower()) for field in csv_header
+        if field.strip() != ""
     ]
     return standardized_csv_header
 
@@ -310,6 +311,7 @@ def process_record_list(
             record=record,
             record_metadata=record_metadata,
         )
+        n_record.pop(None, None)
         yield n_record
 
 

--- a/tests/unit_test/test_s3_csv_etl.py
+++ b/tests/unit_test/test_s3_csv_etl.py
@@ -22,11 +22,12 @@ from dags.s3_csv_import_pipeline import (
     DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE
 )
 
-TEST_DOWNLOADED_SHEET = """'First Name', 'Last_Name', 'Age', 'Univ', 'Country'
-'Michael', 'Bonbi', '7','University of California', 'United States'
-'Robert', 'Alfonso', '', 'Univ of Cambridge', 'France'
-'Michael', 'Shayne', '', '', 'England'
-'Fred', 'Fredrick', '21', '', 'China'
+# pylint: disable=trailing-whitespace
+TEST_DOWNLOADED_SHEET = """'First Name', 'Last_Name', 'Age', 'Univ', 'Country', ''
+'Michael', 'Bonbi', '7','University of California', 'United States',
+'Robert', 'Alfonso', '', 'Univ of Cambridge', 'France',
+'Michael', 'Shayne', '', '', 'England',
+'Fred', 'Fredrick', '21', '', 'China',
 """
 
 
@@ -479,7 +480,8 @@ class TestProcessData:
                 ('last_name', " 'Bonbi'"),
                 ('age', " '7'"),
                 ('univ', "'University of California'"),
-                ('country', " 'United States'")
+                ('country', " 'United States'"),
+                (None, [''])
             ]
         )
         assert next(csv_dict_reader) == expected_value


### PR DESCRIPTION
resolves [#5456](https://github.com/elifesciences/issues/issues/5456)
removes columns with no column name from data uploaded to bigquery