### PR TITLE
fixed flake8 call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 credentials.json
-data_pipeline.egg-info
+*.egg-info
 .pytest_cache
 venv
 main.py
+
+*.pyc

--- a/dags/google_analytics_data_import_pipeline.py
+++ b/dags/google_analytics_data_import_pipeline.py
@@ -14,7 +14,7 @@ from data_pipeline.google_analytics.ga_pipeline import etl_google_analytics
 from data_pipeline.google_analytics.etl_state import (
     get_stored_state, STORED_STATE_FORMAT
 )
-from data_pipeline.utils.dags.data_pipeline_dag_utils import  get_default_args
+from data_pipeline.utils.dags.data_pipeline_dag_utils import get_default_args
 
 
 LOGGER = logging.getLogger(__name__)

--- a/run_test.sh
+++ b/run_test.sh
@@ -21,7 +21,7 @@ PYLINTHOME=/tmp/datahub-dags-pylint \
  pylint tests/ data_pipeline/ dags/
 
 echo "running flake8"
-flake8 flake8  tests/ data_pipeline/
+flake8  tests/ data_pipeline/
 
 
 if [[ $1  &&  $1 == "with-end-to-end" ]]; then

--- a/run_test.sh
+++ b/run_test.sh
@@ -21,7 +21,7 @@ PYLINTHOME=/tmp/datahub-dags-pylint \
  pylint tests/ data_pipeline/ dags/
 
 echo "running flake8"
-flake8  tests/ data_pipeline/
+flake8  tests/ data_pipeline/ dags/
 
 
 if [[ $1  &&  $1 == "with-end-to-end" ]]; then

--- a/tests/dag_validation_test/conftest.py
+++ b/tests/dag_validation_test/conftest.py
@@ -4,7 +4,11 @@ import pytest
 from airflow import models as af_models
 
 DAG_PATH = os.path.join(os.path.dirname(__file__), "../..", "dags")
-DAG_FILES = [f for f in os.listdir(DAG_PATH) if f.endswith(".py")]
+DAG_FILES = [
+    f
+    for f in os.listdir(DAG_PATH)
+    if f.endswith(".py") and not f.startswith("_")
+]
 
 
 @pytest.fixture(name="dagbag", scope="session")


### PR DESCRIPTION
This should fix https://alfred.elifesciences.org/job/data-hub-core-airflow-dags/53/console

I have seen and fixed that in other dags repositories. I believe an old version of flake8 just ignored that.

```text
10:51:44  running flake8
10:51:45  flake8:0:1: E902 FileNotFoundError: [Errno 2] No such file or directory: 'flake8'
10:51:46  Makefile:62: recipe for target 'ci-end2end-test' failed
10:51:46  make: *** [ci-end2end-test] Error 1
```

Also enabled checking the `dags` directory. To make `dev-lint` work for me I had to add the `__init__.py` to the `dags` directory. That itself had to be excluded from `DAG_FILES`.