### PR TITLE
downgraded cattrs to 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,17 @@ RUN echo "airflow ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 
 RUN sed -i 's/LocalExecutor/SequentialExecutor/' /entrypoint.sh
+
+COPY requirements.build.txt ./
+RUN pip install --disable-pip-version-check -r requirements.build.txt
+
 COPY requirements.txt ./
-RUN pip install --upgrade -r requirements.txt
+RUN pip install --disable-pip-version-check --upgrade -r requirements.txt
 RUN if [ "${install_dev}" = "y" ]; then  pip install bokeh; fi
 
 USER airflow
 COPY --chown=airflow:airflow requirements.dev.txt ./
-RUN if [ "${install_dev}" = "y" ]; then pip install --user -r requirements.dev.txt; fi
+RUN if [ "${install_dev}" = "y" ]; then pip install --user --disable-pip-version-check -r requirements.dev.txt; fi
 
 ENV PATH /usr/local/airflow/.local/bin:$PATH
 

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,0 +1,3 @@
+pip==20.2.4
+setuptools==50.3.2
+wheel==0.35.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apache-airflow[crypto,celery,postgres,jdbc,ssh]==1.10.12
 bigquery-schema-generator==1.2
 bigquery-views-manager==1.0.3
 boto3==1.16.7
-cattr==0.9.1
+cattr==1.0.0
 cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apache-airflow[crypto,celery,postgres,jdbc,ssh]==1.10.12
 bigquery-schema-generator==1.2
 bigquery-views-manager==1.0.3
 boto3==1.16.7
-cattr=0.9.1
+cattr==0.9.1
 cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apache-airflow[crypto,celery,postgres,jdbc,ssh]==1.10.12
 bigquery-schema-generator==1.2
 bigquery-views-manager==1.0.3
 boto3==1.16.7
-cattr==1.0.0
+cattrs==1.0.0
 cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ apache-airflow[crypto,celery,postgres,jdbc,ssh]==1.10.12
 bigquery-schema-generator==1.2
 bigquery-views-manager==1.0.3
 boto3==1.16.7
+cattr=0.9.1
 cloudpickle==1.4.1
 dateparser==0.7.6
 dask[complete]==2.30.0


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/100

[cattrs](https://pypi.org/project/cattrs/) version 1.1.0 dropped support for Python 3.5 and Python 3.6. We seem to be using Python 3.7. But perhaps other changes caused it to break.