### PR TITLE
remove bokeh dependency from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN pip install --disable-pip-version-check -r requirements.build.txt
 
 COPY requirements.txt ./
 RUN pip install --disable-pip-version-check --upgrade -r requirements.txt
-RUN if [ "${install_dev}" = "y" ]; then  pip install bokeh; fi
 
 USER airflow
 COPY --chown=airflow:airflow requirements.dev.txt ./

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,11 @@ venv-activate:
 
 
 dev-install:
-	SLUGIFY_USES_TEXT_UNIDECODE=yes $(PIP) install -r requirements.txt
-	$(PIP) install -r requirements.dev.txt
-	$(PIP) install -e . --no-deps
+	$(PIP) install --disable-pip-version-check -r requirements.build.txt
+	SLUGIFY_USES_TEXT_UNIDECODE=yes \
+	$(PIP) install --disable-pip-version-check -r requirements.txt
+	$(PIP) install --disable-pip-version-check -r requirements.dev.txt
+	$(PIP) install --disable-pip-version-check -e . --no-deps
 
 
 dev-venv: venv-create dev-install


### PR DESCRIPTION
The dependency just doesn't belong there and isn't needed.
(If it was needed, then it would be in one of the requirements files)