### PR TITLE
add web api pipeline suffix

### DIFF
--- a/dags/web_api_import_controller.py
+++ b/dags/web_api_import_controller.py
@@ -26,6 +26,11 @@ TARGET_DAG_ID = "Generic_Web_Api_Data_Pipeline"
 DAG_ID = "Web_Api_Data_Import_Pipeline_Controller"
 
 
+def get_web_api_config_suffix(web_api_config: dict) -> str:
+    web_api_config_id = web_api_config.get('id')
+    return '_' + web_api_config_id if web_api_config_id else ''
+
+
 # pylint: disable=unused-argument
 def trigger_web_api_data_import_pipeline_dag(**context):
     conf_file_path = os.getenv(
@@ -34,7 +39,11 @@ def trigger_web_api_data_import_pipeline_dag(**context):
     data_config_dict = get_yaml_file_as_dict(conf_file_path)
     data_config = MultiWebApiConfig(data_config_dict,)
     for web_api_config in data_config.web_api_config.values():
-        simple_trigger_dag(dag_id=TARGET_DAG_ID, conf=web_api_config)
+        simple_trigger_dag(
+            dag_id=TARGET_DAG_ID,
+            conf=web_api_config,
+            suffix=get_web_api_config_suffix(web_api_config)
+        )
 
 
 WEB_API_CONTROLLER_DAG = create_dag(

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -11,6 +11,17 @@ from data_pipeline.utils.pipeline_config import (
 )
 
 
+def get_web_api_config_id(web_api_config_props: dict, index: int) -> str:
+    web_api_config_id = web_api_config_props.get('id')
+    if not web_api_config_id:
+        table_name = web_api_config_props.get('table')
+        if table_name:
+            web_api_config_id = table_name + '_' + str(index)
+        else:
+            web_api_config_id = str(index)
+    return web_api_config_id
+
+
 # pylint: disable=too-many-instance-attributes,too-many-arguments,
 # pylint: disable=too-many-locals
 class MultiWebApiConfig:
@@ -25,6 +36,7 @@ class MultiWebApiConfig:
         self.web_api_config = {
             ind: {
                 **web_api,
+                "id": get_web_api_config_id(web_api, index=ind),
                 "gcpProjectName": self.gcp_project,
                 "importedTimestampFieldName": self.import_timestamp_field_name
             }

--- a/tests/unit_test/dags/web_api_import_controller_test.py
+++ b/tests/unit_test/dags/web_api_import_controller_test.py
@@ -3,7 +3,9 @@ import pytest
 
 from dags import web_api_import_controller
 from dags.web_api_import_controller import (
-    trigger_web_api_data_import_pipeline_dag, TARGET_DAG_ID
+    get_web_api_config_suffix,
+    trigger_web_api_data_import_pipeline_dag,
+    TARGET_DAG_ID
 )
 
 
@@ -22,48 +24,40 @@ def _simple_trigger_dag():
 
 
 class TestData:
+    TEST_WEB_API_CONFIG_ID_1 = "test1"
+    TEST_WEB_API_CONFIG_ID_2 = "test2"
+
+    TEST_DATA_WEB_API_CONFIG_1 = {
+        "id": TEST_WEB_API_CONFIG_ID_1,
+        "datataUrl": {
+            "urlExcludingConfigurableParameters": "url-1",
+            "configurableParameters":
+                {
+                    "pageSizeParameterName": "page-size",
+                }
+        }
+    }
+
+    TEST_DATA_WEB_API_CONFIG_2 = {
+        "id": TEST_WEB_API_CONFIG_ID_2,
+        "datataUrl": {
+            "urlExcludingConfigurableParameters": "url-2",
+            "configurableParameters":
+                {
+                    "pageSizeParameterName": "page-size",
+                }
+        }
+    }
+
     TEST_DATA_MULTI_WEB_API = {
         "gcpProjectName": "test_proj",
         "importedTimestampFieldName": "imported_timestamp",
-        "webApi": [
-            {
-                "datataUrl":
-                    {
-                        "urlExcludingConfigurableParameters": "url-1",
-                        "configurableParameters":
-                            {
-                                "pageSizeParameterName": "page-size",
-                            }
-                    }
-            },
-            {
-                "datataUrl":
-                    {
-                        "urlExcludingConfigurableParameters": "url-2",
-                        "configurableParameters":
-                            {
-                                "pageSizeParameterName": "page-size",
-                            }
-                    }
-            }
-
-        ]
+        "webApi": [TEST_DATA_WEB_API_CONFIG_1, TEST_DATA_WEB_API_CONFIG_2]
     }
     TEST_DATA_SINGLE_WEB_API = {
         "gcpProjectName": "test_proj",
         "importedTimestampFieldName": "imported_timestamp",
-        "webApi": [
-            {
-                "datataUrl":
-                    {
-                        "urlExcludingConfigurableParameters": "url-1",
-                        "configurableParameters":
-                            {
-                                "pageSizeParameterName": "page-size",
-                            }
-                    }
-            }
-        ]
+        "webApi": [TEST_DATA_WEB_API_CONFIG_1]
     }
 
     def __init__(self):
@@ -72,6 +66,14 @@ class TestData:
                 "webApi"
             )
         )
+
+
+class TestGetWebApiConfigSuffix:
+    def test_should_return_underscore_with_id(self):
+        assert get_web_api_config_suffix({'id': '123'}) == '_123'
+
+    def test_should_fallback_to_empty_string(self):
+        assert get_web_api_config_suffix({}) == ''
 
 
 def test_should_call_trigger_dag_function_n_times(
@@ -109,5 +111,6 @@ def test_should_call_trigger_dag_function_with_parameter(
 
     trigger_web_api_data_import_pipeline_dag()
     mock_simple_trigger_dag.assert_called_with(
-        dag_id=TARGET_DAG_ID, conf=single_web_api_config
+        dag_id=TARGET_DAG_ID, conf=single_web_api_config,
+        suffix=get_web_api_config_suffix(TestData.TEST_DATA_WEB_API_CONFIG_1)
     )

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -1,0 +1,29 @@
+from data_pipeline.generic_web_api.generic_web_api_config import (
+    get_web_api_config_id,
+    MultiWebApiConfig
+)
+
+
+class TestGetWebApiConfigId:
+    def test_should_use_id_from_config(self):
+        assert get_web_api_config_id({'id': '123'}, index=0) == '123'
+
+    def test_should_use_output_table_from_config_and_index(self):
+        assert get_web_api_config_id({'table': 'table1'}, index=0) == 'table1_0'
+
+    def test_should_fallback_to_index(self):
+        assert get_web_api_config_id({'other': 'x'}, index=0) == '0'
+
+
+class TestMultiWebApiConfig:
+    def test_should_keep_existing_id_of_web_config(self):
+        multi_web_api_config = MultiWebApiConfig({
+            'webApi': [{'id': '123'}]
+        })
+        assert multi_web_api_config.web_api_config[0]['id'] == '123'
+
+    def test_should_add_id_to_web_config(self):
+        multi_web_api_config = MultiWebApiConfig({
+            'webApi': [{'table': 'table1'}]
+        })
+        assert multi_web_api_config.web_api_config[0]['id'] == 'table1_0'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/94

Because we run the same DAG with different web api config, it makes it hard to distinguish between the runs without opening them and looking at the logs. This will add a suffix that comes from the config. Either the `id` (which we currently don't provide) or the `table` and index of the config.