### PR TITLE
install monitoring requirements to venv and resolve requests conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install --disable-pip-version-check -r requirements.build.txt
 COPY requirements.monitoring.txt ./
 RUN pip install --disable-pip-version-check -r requirements.monitoring.txt
 
+# Note: install requirements together with previous requirements file to make conflicts visible
 COPY requirements.txt ./
 RUN pip install --disable-pip-version-check \
   -r requirements.monitoring.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,18 @@ COPY requirements.monitoring.txt ./
 RUN pip install --disable-pip-version-check -r requirements.monitoring.txt
 
 COPY requirements.txt ./
-RUN pip install --disable-pip-version-check -r requirements.txt
+RUN pip install --disable-pip-version-check \
+  -r requirements.monitoring.txt \
+  -r requirements.txt
 
 ARG install_dev=n
 COPY --chown=airflow:airflow requirements.dev.txt ./
-RUN if [ "${install_dev}" = "y" ]; then pip install --user --disable-pip-version-check -r requirements.dev.txt; fi
+RUN if [ "${install_dev}" = "y" ]; then \
+    pip install --user --disable-pip-version-check \
+      -r requirements.monitoring.txt \
+      -r requirements.txt \
+      -r requirements.dev.txt; \
+  fi
 
 ENV PATH /home/airflow/.local/bin:$PATH
 

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,10 @@ venv-activate:
 dev-install:
 	$(PIP) install --disable-pip-version-check -r requirements.build.txt
 	SLUGIFY_USES_TEXT_UNIDECODE=yes \
-	$(PIP) install --disable-pip-version-check -r requirements.txt
-	$(PIP) install --disable-pip-version-check -r requirements.dev.txt
+	$(PIP) install --disable-pip-version-check \
+		-r requirements.monitoring.txt \
+		-r requirements.txt \
+		-r requirements.dev.txt
 	$(PIP) install --disable-pip-version-check -e . --no-deps
 
 

--- a/requirements.monitoring.txt
+++ b/requirements.monitoring.txt
@@ -3,6 +3,6 @@ pandas==1.3.5
 pandas-gbq==0.17.0
 pyarrow==6.0.1
 tqdm==4.62.3
-requests==2.27.1
+requests==2.23.0
 fsspec==2021.11.1
 s3fs==2021.11.1


### PR DESCRIPTION
When installing dependencies into the virtual environment, it was missing requirements such as `requests`.

A conflict on the `requests` library and `airflow` was shown, after installing the `monitoring` requirements together with the other requirements using a single command.
Previously that was hidden by implicitly downgrading the `requests` library after installing `requirements.txt`.

This is change installs `requirements` together in a single `pip` command to make the conflict visible.
Additionally the `requests` library was downgraded to avoid the conflict with `airflow`.