### PR TITLE
fixed europepmc first_idate should not contain quotes

### DIFF
--- a/data_pipeline/europepmc/europepmc_pipeline.py
+++ b/data_pipeline/europepmc/europepmc_pipeline.py
@@ -52,12 +52,11 @@ def get_request_query_for_source_config_and_start_date_str(
     search_context: EuropePmcSearchContext
 ) -> str:
     date_period_str = (
-        f"[{search_context.start_date_str} TO {search_context.end_date_str}]"
+        f'[{search_context.start_date_str} TO {search_context.end_date_str}]'
     )
-    query = (
-        f"(FIRST_IDATE:{date_period_str}) "
-        + (source_config.search.query or '')
-    ).strip()
+    query = f'(FIRST_IDATE:{date_period_str})'
+    if source_config.search.query:
+        query += ' (' + source_config.search.query + ')'
     return query
 
 

--- a/data_pipeline/europepmc/europepmc_pipeline.py
+++ b/data_pipeline/europepmc/europepmc_pipeline.py
@@ -52,7 +52,7 @@ def get_request_query_for_source_config_and_start_date_str(
     search_context: EuropePmcSearchContext
 ) -> str:
     date_period_str = (
-        f"['{search_context.start_date_str}' TO '{search_context.end_date_str}']"
+        f"[{search_context.start_date_str} TO {search_context.end_date_str}]"
     )
     query = (
         f"(FIRST_IDATE:{date_period_str}) "

--- a/tests/unit_test/europepmc/europepmc_pipeline_test.py
+++ b/tests/unit_test/europepmc/europepmc_pipeline_test.py
@@ -203,7 +203,7 @@ class TestGetRequestQueryForSourceConfigAndInitialState:
             SEARCH_CONTEXT_1
         )
         date_period_str = (
-            f"['{SEARCH_CONTEXT_1.start_date_str}' TO '{SEARCH_CONTEXT_1.end_date_str}']"
+            f"[{SEARCH_CONTEXT_1.start_date_str} TO {SEARCH_CONTEXT_1.end_date_str}]"
         )
         assert query == (
             f"(FIRST_IDATE:{date_period_str})"
@@ -220,7 +220,7 @@ class TestGetRequestQueryForSourceConfigAndInitialState:
             SEARCH_CONTEXT_1
         )
         date_period_str = (
-            f"['{SEARCH_CONTEXT_1.start_date_str}' TO '{SEARCH_CONTEXT_1.end_date_str}']"
+            f"[{SEARCH_CONTEXT_1.start_date_str} TO {SEARCH_CONTEXT_1.end_date_str}]"
         )
         assert query == (
             f"(FIRST_IDATE:{date_period_str})"

--- a/tests/unit_test/europepmc/europepmc_pipeline_test.py
+++ b/tests/unit_test/europepmc/europepmc_pipeline_test.py
@@ -207,7 +207,7 @@ class TestGetRequestQueryForSourceConfigAndInitialState:
         )
         assert query == (
             f"(FIRST_IDATE:{date_period_str})"
-            + f' {original_query}'
+            + f' ({original_query})'
         )
 
     def test_should_return_first_idate_for_none_query(self):
@@ -233,7 +233,7 @@ class TestGetRequestParamsForSourceConfig:
             SOURCE_CONFIG_1,
             SEARCH_CONTEXT_1
         )
-        assert params['query'].endswith(SOURCE_CONFIG_1.search.query)
+        assert SOURCE_CONFIG_1.search.query in params['query']
 
     def test_should_specify_format_json(self):
         params = get_request_params_for_source_config(


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/380

Not sure were the quotes came from. But the effect seems to be that it is ignored.
Additionally the original query needs to be wrapped in brackets.
Otherwise the OR seems to be interpreted differently, resulting in millions of rows in view.