### PR TITLE
fix infinite loop with same cursor

### DIFF
--- a/data_pipeline/europepmc/europepmc_pipeline.py
+++ b/data_pipeline/europepmc/europepmc_pipeline.py
@@ -149,10 +149,14 @@ def iter_article_data(
             cursor=cursor,
             provenance=provenance
         )
-        cursor = get_next_cursor_from_response_json(response_json)
-        LOGGER.debug('response_json (next cursor: %r): %r', cursor, response_json)
+        next_cursor = get_next_cursor_from_response_json(response_json)
+        LOGGER.debug('response_json (next cursor: %r): %r', next_cursor, response_json)
         for data in iter_article_data_from_response_json(response_json):
             yield get_requested_fields_of_the_article_data(data, source_config.fields_to_return)
+        if next_cursor == cursor:
+            LOGGER.warning('ignoring next cursor, same as previous cursor: %r', next_cursor)
+            break
+        cursor = next_cursor
 
 
 def save_state_to_s3_for_config(

--- a/data_pipeline/europepmc/europepmc_pipeline.py
+++ b/data_pipeline/europepmc/europepmc_pipeline.py
@@ -98,9 +98,12 @@ def get_article_response_json_from_api(
         search_context,
         cursor=cursor
     )
+    LOGGER.info('requesting url: %r (%r)', url, params)
     request_timestamp = datetime.utcnow()
     response = requests.get(url, params=params)
     response_timestamp = datetime.utcnow()
+    response_duration_secs = (response_timestamp - request_timestamp).total_seconds()
+    LOGGER.info('request took: %0.3f seconds', response_duration_secs)
     request_provenance = {
         **(provenance or {}),
         'api_url': url,

--- a/tests/unit_test/europepmc/europepmc_pipeline_test.py
+++ b/tests/unit_test/europepmc/europepmc_pipeline_test.py
@@ -450,6 +450,42 @@ class TestIterArticleData:
             )
         ])
 
+    def test_should_ignore_next_cursor_if_same_as_previous_cursor(
+        self,
+        get_article_response_json_from_api_mock: MagicMock
+    ):
+        get_article_response_json_from_api_mock.side_effect = [
+            get_response_json_for_items([
+                ITEM_RESPONSE_JSON_1
+            ], provenance=PROVENANCE_1, nextCursorMark=CURSOR_1),
+            get_response_json_for_items([
+                ITEM_RESPONSE_JSON_2
+            ], provenance=PROVENANCE_1, nextCursorMark=CURSOR_1)
+        ]
+        result = list(iter_article_data(
+            SOURCE_CONFIG_1,
+            SEARCH_CONTEXT_1,
+            provenance=PROVENANCE_1
+        ))
+        assert result == [
+            {**ITEM_RESPONSE_JSON_1, 'provenance': PROVENANCE_1},
+            {**ITEM_RESPONSE_JSON_2, 'provenance': PROVENANCE_1}
+        ]
+        get_article_response_json_from_api_mock.assert_has_calls([
+            call(
+                SOURCE_CONFIG_1,
+                SEARCH_CONTEXT_1,
+                cursor=DEFAULT_CURSOR,
+                provenance=PROVENANCE_1
+            ),
+            call(
+                SOURCE_CONFIG_1,
+                SEARCH_CONTEXT_1,
+                cursor=CURSOR_1,
+                provenance=PROVENANCE_1
+            )
+        ])
+
 
 class TestSaveStateToS3ForConfig:
     def test_should_pass_bucket_and_object_to_upload_s3_object(


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/380

for example `https://www.ebi.ac.uk/europepmc/webservices/test/rest/search?pageSize=1000&query=(FIRST_IDATE%3A[2018-07-10+TO+2018-07-10])+((PUBLISHER%3A%22bioRxiv%22+OR+PUBLISHER%3A%22medRxiv%22))&cursorMark=AoIIPwAsXygzODUyMzUzNw%3D%3D&format=json&resultType=core` returns the same `nextCursorMark` as was passed in, `AoIIPvuPxygzODUyMzUyNA==`.
This seems to be the last page.