### PR TITLE
optionally compress LabsLink XML file

### DIFF
--- a/data_pipeline/europepmc/europepmc_labslink_config.py
+++ b/data_pipeline/europepmc/europepmc_labslink_config.py
@@ -11,6 +11,9 @@ from data_pipeline.utils.pipeline_config import (
 LOGGER = logging.getLogger(__name__)
 
 
+DEFAULT_LINKS_XML_FTP_FILENAME = 'links.xml'
+
+
 class BigQuerySourceConfig(NamedTuple):
     project_name: str
     sql_query: str
@@ -57,6 +60,7 @@ class FtpTargetConfig:
     password: str = field(repr=False)
     directory_name: str = field(repr=False)
     create_directory: bool = False
+    links_xml_filename: str = DEFAULT_LINKS_XML_FTP_FILENAME
 
     @staticmethod
     def from_dict(ftp_target_config_dict: dict) -> 'FtpTargetConfig':
@@ -69,7 +73,11 @@ class FtpTargetConfig:
             username=ftp_target_config_dict['username'],
             password=secrets['password'],
             directory_name=secrets['directoryName'],
-            create_directory=ftp_target_config_dict.get('createDirectory', False)
+            create_directory=ftp_target_config_dict.get('createDirectory', False),
+            links_xml_filename=ftp_target_config_dict.get(
+                'linksXmlFilename',
+                DEFAULT_LINKS_XML_FTP_FILENAME
+            )
         )
 
     def _replace(self, **changes) -> 'FtpTargetConfig':

--- a/data_pipeline/europepmc/europepmc_labslink_pipeline.py
+++ b/data_pipeline/europepmc/europepmc_labslink_pipeline.py
@@ -22,9 +22,6 @@ from data_pipeline.utils.data_store.bq_data_service import (
 LOGGER = logging.getLogger(__name__)
 
 
-LINKS_XML_FTP_FILENAME = 'links.xml'
-
-
 class LabsLinkElementMakers:
     LINKS = E.links
     LINK = E.link
@@ -130,7 +127,7 @@ def update_labslink_ftp(
     )
     LOGGER.info('uploading file')
     with open(source_xml_file_path, 'rb') as xml_fp:
-        ftp.storbinary(cmd=f'STOR {LINKS_XML_FTP_FILENAME}', fp=xml_fp)
+        ftp.storbinary(cmd=f'STOR {ftp_target_config.links_xml_filename}', fp=xml_fp)
 
 
 def fetch_article_dois_from_bigquery_and_update_labslink_ftp(

--- a/sample_data_config/europepmc/europepmc-labslink.config.yaml
+++ b/sample_data_config/europepmc/europepmc-labslink.config.yaml
@@ -18,6 +18,7 @@ europePmcLabsLink:
         port: 21
         username: 'elinks'
         createDirectory: true
+        linksXmlFilename: links.xml
         parametersFromFile:
           - parameterName: password
             filePathEnvName: EUROPEPMC_LABSLINK_FTP_PASSWORD_FILE_PATH

--- a/sample_data_config/europepmc/europepmc-labslink.config.yaml
+++ b/sample_data_config/europepmc/europepmc-labslink.config.yaml
@@ -18,7 +18,7 @@ europePmcLabsLink:
         port: 21
         username: 'elinks'
         createDirectory: true
-        linksXmlFilename: links.xml
+        linksXmlFilename: test-links.xml.gz
         parametersFromFile:
           - parameterName: password
             filePathEnvName: EUROPEPMC_LABSLINK_FTP_PASSWORD_FILE_PATH

--- a/tests/end2end_test/europepmc_labslink_end_to_end_test.py
+++ b/tests/end2end_test/europepmc_labslink_end_to_end_test.py
@@ -1,5 +1,6 @@
 import ftplib
 import logging
+import gzip
 from io import BytesIO
 
 from lxml import etree
@@ -10,7 +11,8 @@ from dags.europepmc_labslink_data_export_pipeline import (
 )
 from data_pipeline.europepmc.europepmc_labslink_pipeline import (
     change_or_create_ftp_directory,
-    get_connected_ftp_client
+    get_connected_ftp_client,
+    is_gzip_file_path
 )
 
 from tests.end2end_test import (
@@ -52,6 +54,9 @@ def test_dag_runs_and_uploads_file():
     data = BytesIO()
     ftp.retrbinary(f'RETR {filename}', callback=data.write)
     xml_str = data.getvalue()
+    if is_gzip_file_path(filename):
+        LOGGER.info('gzip decompressing file: %d bytes', len(xml_str))
+        xml_str = gzip.decompress(xml_str)
     LOGGER.info('checking valid xml: %d bytes', len(xml_str))
     assert_valid_xml_str(xml_str)
     LOGGER.info('done')

--- a/tests/end2end_test/europepmc_labslink_end_to_end_test.py
+++ b/tests/end2end_test/europepmc_labslink_end_to_end_test.py
@@ -9,7 +9,6 @@ from dags.europepmc_labslink_data_export_pipeline import (
     get_pipeline_config
 )
 from data_pipeline.europepmc.europepmc_labslink_pipeline import (
-    LINKS_XML_FTP_FILENAME,
     change_or_create_ftp_directory,
     get_connected_ftp_client
 )
@@ -39,7 +38,7 @@ def test_dag_runs_and_uploads_file():
         directory_name=ftp_target_config.directory_name,
         create_directory=ftp_target_config.create_directory
     )
-    filename = LINKS_XML_FTP_FILENAME
+    filename = ftp_target_config.links_xml_filename
     try:
         LOGGER.info('deleting %r, if it exists', filename)
         ftp.delete(filename)

--- a/tests/unit_test/europepmc/europepmc_labslink_config_test.py
+++ b/tests/unit_test/europepmc/europepmc_labslink_config_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from data_pipeline.europepmc.europepmc_labslink_config import (
+    DEFAULT_LINKS_XML_FTP_FILENAME,
     EuropePmcLabsLinkConfig
 )
 
@@ -22,6 +23,7 @@ SOURCE_CONFIG_DICT_1 = {
 
 PASSWORD_1 = 'password1'
 DIRECTORY_NAME_1 = 'directory name1'
+LINKS_XML_FILENAME_1 = 'links1.xml'
 
 FTP_PASSWORD_FILE_PATH_ENV_VAR = 'FTP_PASSWORD_FILE_PATH_ENV_VAR'
 FTP_DIRECTORY_NAME_FILE_PATH_ENV_VAR = 'FTP_DIRECTORY_NAME_FILE_PATH_ENV_VAR'
@@ -103,6 +105,20 @@ class TestEuropeLabsLinkPmcConfig:
         assert config.target.ftp.hostname == FTP_TARGET_CONFIG_DICT_1['hostname']
         assert config.target.ftp.port == FTP_TARGET_CONFIG_DICT_1['port']
         assert config.target.ftp.username == FTP_TARGET_CONFIG_DICT_1['username']
+
+    def test_should_use_default_ftp_links_xml_filename(self):
+        config = EuropePmcLabsLinkConfig.from_dict(CONFIG_DICT_1)
+        assert config.target.ftp.links_xml_filename == DEFAULT_LINKS_XML_FTP_FILENAME
+
+    def test_should_read_target_ftp_links_xml_filename(self):
+        config = EuropePmcLabsLinkConfig.from_dict(get_config_for_item_config_dict({
+            **ITEM_CONFIG_DICT_1,
+            'target': {'ftp': {
+                **FTP_TARGET_CONFIG_DICT_1,
+                'linksXmlFilename': LINKS_XML_FILENAME_1
+            }}
+        }))
+        assert config.target.ftp.links_xml_filename == LINKS_XML_FILENAME_1
 
     def test_should_set_target_ftp_create_target_directory_to_false_by_default(self):
         config = EuropePmcLabsLinkConfig.from_dict(CONFIG_DICT_1)

--- a/tests/unit_test/europepmc/europepmc_labslink_pipeline_test.py
+++ b/tests/unit_test/europepmc/europepmc_labslink_pipeline_test.py
@@ -17,7 +17,6 @@ from data_pipeline.europepmc.europepmc_labslink_config import (
 )
 import data_pipeline.europepmc.europepmc_labslink_pipeline as europepmc_labslink_pipeline_module
 from data_pipeline.europepmc.europepmc_labslink_pipeline import (
-    LINKS_XML_FTP_FILENAME,
     fetch_article_dois_from_bigquery_and_update_labslink_ftp,
     fetch_article_dois_from_bigquery,
     generate_labslink_links_xml_to_file_from_doi_list,
@@ -51,7 +50,8 @@ FTP_TARGET_CONFIG_1 = FtpTargetConfig(
     port=123,
     username='user1',
     password='password1',
-    directory_name='dir1'
+    directory_name='dir1',
+    links_xml_filename='links1.xml'
 )
 
 TARGET_CONFIG_1 = EuropePmcLabsLinkTargetConfig(
@@ -195,7 +195,7 @@ class TestUpdateLabsLinkFtp:
         )
         ftp_mock.cwd.assert_called_with(FTP_TARGET_CONFIG_1.directory_name)
         ftp_mock.storbinary.assert_called_with(
-            cmd=f'STOR {LINKS_XML_FTP_FILENAME}',
+            cmd=f'STOR {FTP_TARGET_CONFIG_1.links_xml_filename}',
             fp=ANY
         )
 

--- a/tests/unit_test/europepmc/europepmc_labslink_pipeline_test.py
+++ b/tests/unit_test/europepmc/europepmc_labslink_pipeline_test.py
@@ -1,5 +1,6 @@
 import ftplib
 import logging
+import gzip
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
@@ -114,6 +115,10 @@ def _update_labslink_ftp_mock() -> MagicMock:
         yield mock
 
 
+def _check_valid_xml_str(xml_str: bytes):
+    etree.fromstring(xml_str)
+
+
 class TestFetchArticleDoisFromBigQuery:
     def test_should_call_get_single_column_value_list_from_bq_query(
         self,
@@ -169,6 +174,15 @@ class TestGenerateLabsLinkLinksXmlToFileFromDoiList:
         assert first_line.startswith('<?xml')
         assert "encoding='UTF-8'" in first_line
         assert "standalone='yes'" in first_line
+
+    def test_should_gzip_compress_for_filenames_with_gz_extension(self, tmp_path: Path):
+        xml_path = tmp_path / 'links.xml.gz'
+        generate_labslink_links_xml_to_file_from_doi_list(
+            file_path=str(xml_path),
+            doi_list=DOI_LIST,
+            xml_config=XML_CONFIG_1
+        )
+        _check_valid_xml_str(gzip.decompress(xml_path.read_bytes()))
 
 
 class TestUpdateLabsLinkFtp:
@@ -279,3 +293,14 @@ class TestFetchArticleDoisFromBigQueryAndUpdateLabsLinkFtp:
             source_xml_file_path=expected_file_path,
             ftp_target_config=FTP_TARGET_CONFIG_1
         )
+
+    def test_should_pass_configured_links_xml_filename_to_generate_function(
+        self,
+        generate_labslink_links_xml_to_file_from_doi_list_mock: MagicMock
+    ):
+        fetch_article_dois_from_bigquery_and_update_labslink_ftp(
+            CONFIG_1
+        )
+        _args, kwargs = generate_labslink_links_xml_to_file_from_doi_list_mock.call_args
+        links_xml_file_path = kwargs['file_path']
+        assert links_xml_file_path.endswith(CONFIG_1.target.ftp.links_xml_filename)


### PR DESCRIPTION
This enabled gzip compression for the links xml filenames.
This can be configured by way of using for example `links.xml.gz` as the `linksXmlFilename`