### PR TITLE
fixed urllib3.util.retry import

### DIFF
--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -1,7 +1,7 @@
 import requests
 from requests.adapters import HTTPAdapter
-# pylint: disable=import-error
-from requests.packages.urllib3.util.retry import Retry
+
+from urllib3.util.retry import Retry
 
 
 def requests_retry_session(


### PR DESCRIPTION
importing via `requests` is deprecated.