### PR TITLE
skip semantic scholar failures

### DIFF
--- a/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
+++ b/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
@@ -102,7 +102,9 @@ def fetch_article_data_from_semantic_scholar_and_load_into_bigquery(
     provenance = {'imported_timestamp': datetime.utcnow().isoformat()}
     doi_iterable = iter_doi_for_matrix_config(config.matrix)
     with requests_retry_session(
-        status_forcelist=(500, 502, 503, 504, 429)
+        status_forcelist=(500, 502, 503, 504, 429),
+        raise_on_redirect=False,  # avoid raising exception, instead we will save response as is
+        raise_on_status=False
     ) as session:
         data_iterable = iter_article_data(
             doi_iterable,

--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -5,10 +5,10 @@ from urllib3.util.retry import Retry
 
 
 def requests_retry_session(
-        retries=10,
-        backoff_factor=0.3,
-        status_forcelist=(500, 502, 504),
-        session=None,
+    retries=10,
+    backoff_factor=0.3,
+    status_forcelist=(500, 502, 504),
+    session=None,
 ):
     session = session or requests.Session()
     retry = Retry(

--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -10,6 +10,7 @@ def requests_retry_session(
     backoff_factor: float = 0.3,
     status_forcelist: Iterable[int] = (500, 502, 504),
     session: Optional[requests.Session] = None,
+    **kwargs
 ) -> requests.Session:
     session = session or requests.Session()
     retry = Retry(
@@ -18,6 +19,7 @@ def requests_retry_session(
         connect=retries,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        **kwargs
     )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)

--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -1,3 +1,4 @@
+from typing import Iterable, Optional
 import requests
 from requests.adapters import HTTPAdapter
 
@@ -5,11 +6,11 @@ from urllib3.util.retry import Retry
 
 
 def requests_retry_session(
-    retries=10,
-    backoff_factor=0.3,
-    status_forcelist=(500, 502, 504),
-    session=None,
-):
+    retries: int = 10,
+    backoff_factor: float = 0.3,
+    status_forcelist: Iterable[int] = (500, 502, 504),
+    session: Optional[requests.Session] = None,
+) -> requests.Session:
     session = session or requests.Session()
     retry = Retry(
         total=retries,


### PR DESCRIPTION
extension of #961

Currently, when the API request fails and is one of the listed status codes to try again, then the request will be retried so many times (10). If that still fails, then it will raise an exception and stop processing.

The intention was that it would retry, but if that still fails, it would just save the response and carry on.