### PR TITLE
skip semantic scholar failures v2

### DIFF
--- a/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
+++ b/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
@@ -75,7 +75,8 @@ def get_article_response_json_from_api(
         url,
         params=params,
         provenance=provenance,
-        session=session
+        session=session,
+        raise_on_status=False
     )
 
 

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -61,7 +61,10 @@ def get_response_json_with_provenance_from_api(
     response_timestamp = datetime.utcnow()
     LOGGER.debug('raise_on_status: %r', raise_on_status)
     response_duration_secs = (response_timestamp - request_timestamp).total_seconds()
-    LOGGER.info('request took: %0.3f seconds', response_duration_secs)
+    LOGGER.info(
+        'request took: %0.3f seconds (status_code: %r)',
+        response_duration_secs, response.status_code
+    )
     if raise_on_status:
         response.raise_for_status()
     request_provenance = {

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -45,14 +45,20 @@ def get_valid_json_from_response(response: requests.Response) -> dict:
         raise
 
 
-def get_response_json_with_provenance_from_api(
+def get_response_json_with_provenance_from_api(  # pylint: disable=too-many-arguments
     url: str,
     params: Mapping[str, str] = None,
     provenance: Optional[Mapping[str, str]] = None,
     session: Optional[requests.Session] = None,
-    raise_on_status: bool = True
+    raise_on_status: bool = True,
+    progress_message: Optional[str] = None
 ) -> dict:
-    LOGGER.info('requesting url: %r (%r)', url, params)
+    progress_message_str = (
+        f'({progress_message})'
+        if progress_message
+        else ''
+    )
+    LOGGER.info('requesting url%s: %r (%r)', progress_message_str, url, params)
     request_timestamp = datetime.utcnow()
     if session:
         response = session.get(url, params=params)

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -60,10 +60,10 @@ def get_response_json_with_provenance_from_api(
         response = requests.get(url, params=params)
     response_timestamp = datetime.utcnow()
     LOGGER.debug('raise_on_status: %r', raise_on_status)
-    if raise_on_status:
-        response.raise_for_status()
     response_duration_secs = (response_timestamp - request_timestamp).total_seconds()
     LOGGER.info('request took: %0.3f seconds', response_duration_secs)
+    if raise_on_status:
+        response.raise_for_status()
     request_provenance = {
         **(provenance or {}),
         'api_url': url,

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -39,7 +39,6 @@ def fetch_single_column_value_list_for_bigquery_source_config(
 
 def get_valid_json_from_response(response: requests.Response) -> dict:
     try:
-        response.raise_for_status()
         return response.json()
     except JSONDecodeError:
         LOGGER.warning('failed to decode json: %r', response.text)
@@ -50,7 +49,8 @@ def get_response_json_with_provenance_from_api(
     url: str,
     params: Mapping[str, str] = None,
     provenance: Optional[Mapping[str, str]] = None,
-    session: Optional[requests.Session] = None
+    session: Optional[requests.Session] = None,
+    raise_on_status: bool = True
 ) -> dict:
     LOGGER.info('requesting url: %r (%r)', url, params)
     request_timestamp = datetime.utcnow()
@@ -59,6 +59,9 @@ def get_response_json_with_provenance_from_api(
     else:
         response = requests.get(url, params=params)
     response_timestamp = datetime.utcnow()
+    LOGGER.debug('raise_on_status: %r', raise_on_status)
+    if raise_on_status:
+        response.raise_for_status()
     response_duration_secs = (response_timestamp - request_timestamp).total_seconds()
     LOGGER.info('request took: %0.3f seconds', response_duration_secs)
     request_provenance = {

--- a/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
+++ b/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
@@ -222,7 +222,8 @@ class TestGetArticleResponseJsonFromApi:
             get_resolved_api_url(SOURCE_CONFIG_1.api_url, doi=DOI_1),
             params=SOURCE_CONFIG_1.params,
             provenance=None,
-            session=session_mock
+            session=session_mock,
+            raise_on_status=False
         )
 
 

--- a/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
+++ b/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
@@ -19,6 +19,7 @@ from data_pipeline.semantic_scholar import (
 from data_pipeline.semantic_scholar.semantic_scholar_pipeline import (
     get_article_response_json_from_api,
     fetch_article_data_from_semantic_scholar_and_load_into_bigquery,
+    get_progress_message,
     get_resolved_api_url,
     iter_article_data,
     iter_doi_for_matrix_config
@@ -216,15 +217,25 @@ class TestGetArticleResponseJsonFromApi:
             DOI_1,
             source_config=SOURCE_CONFIG_1,
             provenance=None,
-            session=session_mock
+            session=session_mock,
+            progress_message='progress1'
         )
         get_response_json_with_provenance_from_api_mock.assert_called_with(
             get_resolved_api_url(SOURCE_CONFIG_1.api_url, doi=DOI_1),
             params=SOURCE_CONFIG_1.params,
             provenance=None,
             session=session_mock,
-            raise_on_status=False
+            raise_on_status=False,
+            progress_message='progress1'
         )
+
+
+class TestGetProgressMessage:
+    def test_should_return_position_only_if_iterable_has_no_size(self):
+        assert get_progress_message(0, iter([DOI_1])) == '1'
+
+    def test_should_return_position_with_total_if_iterable_has_size(self):
+        assert get_progress_message(0, [DOI_1]) == '1/1'
 
 
 class TestIterArticleData:
@@ -233,8 +244,9 @@ class TestIterArticleData:
         session_mock: MagicMock,
         get_article_response_json_from_api_mock: MagicMock
     ):
+        doi_iterable = iter([DOI_1])
         result = list(iter_article_data(
-            [DOI_1],
+            doi_iterable,
             source_config=SOURCE_CONFIG_1,
             provenance=PROVENANCE_1,
             session=session_mock
@@ -244,7 +256,8 @@ class TestIterArticleData:
             DOI_1,
             source_config=SOURCE_CONFIG_1,
             provenance=PROVENANCE_1,
-            session=session_mock
+            session=session_mock,
+            progress_message=get_progress_message(0, doi_iterable)
         )
 
 


### PR DESCRIPTION
Extension of #961 and #966

The previous fix only address retries. There was still a `raise_for_status` present.

So this is now disabling that too.
Additionally it is showing some sort of progress.

e.g.:

> 2022-05-03 16:35:44,864] {pipeline_utils.py:61} INFO - requesting url(1/186165): 'https://api.semanticscholar.org/graph/v1/paper/10.1101/2022.03.14.22272372' ...
[2022-05-03 16:38:22,295] {pipeline_utils.py:72} INFO - request took: 157.431 seconds (status_code: 200)

and an example with an error:

> [2022-05-03 16:38:32,288] {pipeline_utils.py:61} INFO - requesting url(16/186165): 'https://api.semanticscholar.org/graph/v1/paper/10.1101/2022.03.16.22272491' ...
[2022-05-03 16:38:32,901] {pipeline_utils.py:72} INFO - request took: 0.613 seconds (status_code: 404)