### PR TITLE
include doi in semantic scholar provenance

### DIFF
--- a/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
+++ b/data_pipeline/semantic_scholar/semantic_scholar_pipeline.py
@@ -71,10 +71,14 @@ def get_article_response_json_from_api(
     )
     params = get_request_params_for_source_config(source_config)
     LOGGER.debug('resolved url: %r (%r)', url, params)
+    extended_provenance = {
+        **(provenance or {}),
+        'doi': doi
+    }
     return get_response_json_with_provenance_from_api(
         url,
         params=params,
-        provenance=provenance,
+        provenance=extended_provenance,
         session=session,
         raise_on_status=False,
         progress_message=progress_message

--- a/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
+++ b/tests/unit_test/semantic_scholar/semantic_scholar_pipeline_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -223,11 +224,39 @@ class TestGetArticleResponseJsonFromApi:
         get_response_json_with_provenance_from_api_mock.assert_called_with(
             get_resolved_api_url(SOURCE_CONFIG_1.api_url, doi=DOI_1),
             params=SOURCE_CONFIG_1.params,
-            provenance=None,
+            provenance=ANY,
             session=session_mock,
             raise_on_status=False,
             progress_message='progress1'
         )
+
+    @pytest.mark.parametrize(
+        'input_provenance,expected_provenance', [
+            (
+                None,
+                {'doi': DOI_1}
+            ),
+            (
+                {'other_key': 'other_value'},
+                {'other_key': 'other_value', 'doi': DOI_1}
+            )
+        ])
+    def test_should_add_doi_to_provenance(
+        self,
+        session_mock: MagicMock,
+        get_response_json_with_provenance_from_api_mock: MagicMock,
+        input_provenance: Optional[dict],
+        expected_provenance: dict
+    ):
+        get_article_response_json_from_api(
+            DOI_1,
+            source_config=SOURCE_CONFIG_1,
+            provenance=input_provenance,
+            session=session_mock,
+            progress_message='progress1'
+        )
+        _args, kwargs = get_response_json_with_provenance_from_api_mock.call_args
+        assert kwargs['provenance'] == expected_provenance
 
 
 class TestGetProgressMessage:


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/432

Currently we don't include the `doi` in the provenance but rely on it being included in the response as external identifiers.
That creates an issue for error response that we save but then don't include the DOI.
It can then only be inferred from the URL.

This makes it difficult to for example only retry 404s after a certain period.

This PR add it to the provenance.
We could backfill from the URL afterwards.