### PR TITLE
fix semantic scholar recommendation date metadata

### DIFF
--- a/data_pipeline/utils/json.py
+++ b/data_pipeline/utils/json.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Callable, Optional, Tuple, TypeVar
 import pandas as pd
 import numpy as np
@@ -13,6 +13,8 @@ def get_json_compatible_value(value):
     but less dependent on the actual serialization.
     """
     if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
         return value.isoformat()
     return value
 

--- a/sample_data_config/semantic-scholar/semantic-scholar-recommendation.config.yaml
+++ b/sample_data_config/semantic-scholar/semantic-scholar-recommendation.config.yaml
@@ -44,8 +44,13 @@ semanticScholarRecommendation:
 
                   -- list with the latest saved article
                   SELECT
-                      CONCAT(list_key, '|list_hash:', list_hash, '|request_type:current_events') AS list_key,
-                      STRUCT(user_id, list_hash, 'current_events' AS request_type) AS list_meta,
+                      CONCAT(
+                          list_key,
+                          '|list_hash:', list_hash,
+                          '|request_type:current_events',
+                          '|request_date=', FORMAT_DATE('%Y-%m-%d', CURRENT_DATE())  -- include request_date to update current recommendations daily
+                      ) AS list_key,
+                      STRUCT(user_id, list_hash, 'current_events' AS request_type, CURRENT_DATE() AS request_date) AS list_meta,
                       list
                   FROM t_list
 
@@ -54,7 +59,7 @@ semanticScholarRecommendation:
                   -- list before the latest saved article, for evaluation purpose
                   SELECT
                       CONCAT(list_key, '|list_hash:', list_hash, '|request_type:prev_events') AS list_key,
-                      STRUCT(user_id, list_hash, 'prev_events' AS request_type) AS list_meta,
+                      STRUCT(user_id, list_hash, 'prev_events' AS request_type, CURRENT_DATE() AS request_date) AS list_meta,
                       -- remove last item
                       ARRAY(
                           SELECT AS STRUCT * EXCEPT(OFFSET)

--- a/tests/unit_test/utils/json_test.py
+++ b/tests/unit_test/utils/json_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 import numpy as np
 
@@ -13,6 +13,8 @@ from data_pipeline.utils.json import (
 # reformatting to avoid issues with changes to formatting
 DATETIME_STR_1 = datetime.fromisoformat('2021-02-03T04:05:06+00:00').isoformat()
 
+DATE_STR_1 = date.fromisoformat('2021-02-03').isoformat()
+
 
 class TestGetJsonCompatibleValue:
     def test_should_not_change_str(self):
@@ -20,6 +22,9 @@ class TestGetJsonCompatibleValue:
 
     def test_should_format_datetime(self):
         assert get_json_compatible_value(datetime.fromisoformat(DATETIME_STR_1)) == DATETIME_STR_1
+
+    def test_should_format_date(self):
+        assert get_json_compatible_value(date.fromisoformat(DATE_STR_1)) == DATE_STR_1
 
 
 class TestGetRecursiveJsonCompatibleValue:


### PR DESCRIPTION
dates where not formatted and caused issues when adding a date typed field to the `list_meta` field of the Semantic Scholar recommendations in https://github.com/elifesciences/elife-flux-cluster/pull/729

Somewhat related to https://github.com/elifesciences/data-hub-issues/issues/480 (as we don't see the failed responses in BigQuery)