### PR TITLE
Updated CrossRef and Web api timeout

### DIFF
--- a/dags/crossref_event_data_import_pipeline.py
+++ b/dags/crossref_event_data_import_pipeline.py
@@ -53,7 +53,7 @@ CROSSREF_DAG = create_dag(
     schedule_interval=get_env_var_or_use_default(
         CROSS_REF_IMPORT_SCHEDULE_INTERVAL_ENV_NAME
     ),
-    dagrun_timeout=timedelta(minutes=60)
+    dagrun_timeout=timedelta(days=1)
 )
 
 

--- a/dags/web_api_data_import_pipeline.py
+++ b/dags/web_api_data_import_pipeline.py
@@ -26,7 +26,7 @@ DAG_ID = "Generic_Web_Api_Data_Pipeline"
 GENERIC_WEB_API_DATA = create_dag(
     dag_id=DAG_ID,
     schedule_interval=None,
-    dagrun_timeout=timedelta(minutes=60)
+    dagrun_timeout=timedelta(days=1)
 )
 
 


### PR DESCRIPTION
https://github.com/elifesciences/data-hub-issues/issues/553#issuecomment-1342428326
log:

```log
[2022-12-08, 11:27:59 UTC] {etl_crossref_event_data_util.py:106} INFO - url: https://api.eventdata.crossref.org/v1/events?rows=100&mailto=h.ciplak@elifesciences.org&from-collected-date=2000-01-01&obj-id.prefix=10.1101
[2022-12-08, 11:28:00 UTC] {local_task_job.py:221} WARNING - DagRun timed out after 1:00:10.307372.
[2022-12-08, 11:28:00 UTC] {local_task_job.py:227} WARNING - State of this instance has been externally set to skipped. Terminating instance.
[2022-12-08, 11:28:00 UTC] {process_utils.py:129} INFO - Sending Signals.SIGTERM to group 4057. PIDs of all processes in the group: [4057]
[2022-12-08, 11:28:00 UTC] {process_utils.py:129} INFO - Sending Signals.SIGTERM to group 4057. PIDs of all processes in the group: [4057]
[2022-12-08, 11:28:00 UTC] {process_utils.py:84} INFO - Sending the signal Signals.SIGTERM to group 4057
[2022-12-08, 11:28:00 UTC] {process_utils.py:84} INFO - Sending the signal Signals.SIGTERM to group 4057
[2022-12-08, 11:28:00 UTC] {taskinstance.py:1562} ERROR - Received SIGTERM. Terminating subprocesses.
[2022-12-08, 11:28:00 UTC] {taskinstance.py:1562} ERROR - Received SIGTERM. Terminating subprocesses.
[2022-12-08, 11:28:00 UTC] {process_utils.py:79} INFO - Process psutil.Process(pid=4057, status='terminated', exitcode=0, started='10:28:01') (4057) terminated with exit code 0
[2022-12-08, 11:28:00 UTC] {process_utils.py:79} INFO - Process psutil.Process(pid=4057, status='terminated', exitcode=0, started='10:28:01') (4057) terminated with exit code 0
```