### PR TITLE
crossref event data use default data collection start date

### DIFF
--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -27,8 +27,8 @@ def _download_s3_object_as_string_or_file_not_found_error_mock_mock(
     test_download_exception: bool = False
 ):
     with patch.object(
-            etl_crossref_event_data_util_module,
-            "download_s3_object_as_string_or_file_not_found_error"
+        etl_crossref_event_data_util_module,
+        "download_s3_object_as_string_or_file_not_found_error"
     ) as mock:
         mock.return_value = publisher_latest_date_dict
         if test_download_exception:

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -23,19 +23,13 @@ from data_pipeline.utils import pipeline_file_io as pipeline_file_io_module
 
 @pytest.fixture(name="download_s3_object_as_string_or_file_not_found_error_mock")
 def _download_s3_object_as_string_or_file_not_found_error_mock_mock(
-    publisher_latest_date_dict: dict,
-    test_download_exception: bool = False
+    publisher_latest_date_dict: dict
 ):
     with patch.object(
         etl_crossref_event_data_util_module,
         "download_s3_object_as_string_or_file_not_found_error"
     ) as mock:
         mock.return_value = publisher_latest_date_dict
-        if test_download_exception:
-            mock.side_effect = BaseException
-            mock.return_value = (
-                etl_crossref_event_data_util_module.
-                EtlModuleConstant.DEFAULT_DATA_COLLECTION_START_DATE)
         yield mock
 
 

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -21,9 +21,11 @@ from data_pipeline.utils.pipeline_file_io import (
 from data_pipeline.utils import pipeline_file_io as pipeline_file_io_module
 
 
-@pytest.fixture(name="mock_download_s3_object")
-def _download_s3_object(publisher_latest_date,
-                        test_download_exception: bool = False):
+@pytest.fixture(name="download_s3_object_as_string_or_file_not_found_error_mock")
+def _download_s3_object_as_string_or_file_not_found_error_mock_mock(
+    publisher_latest_date,
+    test_download_exception: bool = False
+):
     with patch.object(
             etl_crossref_event_data_util_module,
             "download_s3_object_as_string_or_file_not_found_error"
@@ -139,26 +141,30 @@ class TestGetNewDataDownloadStartDateFromCloudStorage:
     )
     def test_should_get_last_data_collection_date_from_cloud_storage(
         self,
-        mock_download_s3_object,
+        download_s3_object_as_string_or_file_not_found_error_mock,
         number_of_prv_days,
         data_download_start_date,
     ):
         from_date = get_new_data_download_start_date_from_cloud_storage(
             "bucket", "object_key", number_of_prv_days
         )
-        mock_download_s3_object.assert_called_with("bucket", "object_key")
+        (
+            download_s3_object_as_string_or_file_not_found_error_mock
+            .assert_called_with("bucket", "object_key")
+        )
         assert from_date == data_download_start_date
 
-    # parameter required because mock_download_s3_object depends on it
+    # parameter required because
+    # download_s3_object_as_string_or_file_not_found_error_mock depends on it
     @pytest.mark.parametrize(
         "publisher_latest_date",
         [{"A": "2019-10-23"}],
     )
     def test_should_return_empty_dict_if_state_file_not_found(
         self,
-        mock_download_s3_object: MagicMock
+        download_s3_object_as_string_or_file_not_found_error_mock: MagicMock
     ):
-        mock_download_s3_object.side_effect = FileNotFoundError()
+        download_s3_object_as_string_or_file_not_found_error_mock.side_effect = FileNotFoundError()
         from_date = get_new_data_download_start_date_from_cloud_storage(
             "bucket", "object_key", 1
         )

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -129,7 +129,7 @@ def test_should_download_crossref_event_data(
 
 
 # pylint: disable=unused-argument
-class TestGetNewDataDownloadStartDateFromCloudStorage:    
+class TestGetNewDataDownloadStartDateFromCloudStorage:
     @pytest.mark.parametrize(
         "publisher_latest_date, number_of_prv_days, "
         "data_download_start_date",

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -129,24 +129,26 @@ def test_should_download_crossref_event_data(
 
 
 # pylint: disable=unused-argument
-@pytest.mark.parametrize(
-    "publisher_latest_date, number_of_prv_days, "
-    "data_download_start_date",
-    [
-        ({"A": "2019-10-23"}, 1, {"A": "2019-10-22"}),
-        ({"A": "2016-09-23"}, 7, {"A": "2016-09-16"})
-    ],
-)
-def test_should_get_last_data_collection_date_from_cloud_storage(
+class TestGetNewDataDownloadStartDateFromCloudStorage:    
+    @pytest.mark.parametrize(
+        "publisher_latest_date, number_of_prv_days, "
+        "data_download_start_date",
+        [
+            ({"A": "2019-10-23"}, 1, {"A": "2019-10-22"}),
+            ({"A": "2016-09-23"}, 7, {"A": "2016-09-16"})
+        ],
+    )
+    def test_should_get_last_data_collection_date_from_cloud_storage(
+        self,
         mock_download_s3_object,
         number_of_prv_days,
         data_download_start_date,
-):
-    from_date = get_new_data_download_start_date_from_cloud_storage(
-        "bucket", "object_key", number_of_prv_days
-    )
-    mock_download_s3_object.assert_called_with("bucket", "object_key")
-    assert from_date == data_download_start_date
+    ):
+        from_date = get_new_data_download_start_date_from_cloud_storage(
+            "bucket", "object_key", number_of_prv_days
+        )
+        mock_download_s3_object.assert_called_with("bucket", "object_key")
+        assert from_date == data_download_start_date
 
 
 def test_should_convert_bq_schema_field_list_to_dict():

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -23,14 +23,14 @@ from data_pipeline.utils import pipeline_file_io as pipeline_file_io_module
 
 @pytest.fixture(name="download_s3_object_as_string_or_file_not_found_error_mock")
 def _download_s3_object_as_string_or_file_not_found_error_mock_mock(
-    publisher_latest_date,
+    publisher_latest_date_dict: dict,
     test_download_exception: bool = False
 ):
     with patch.object(
             etl_crossref_event_data_util_module,
             "download_s3_object_as_string_or_file_not_found_error"
     ) as mock:
-        mock.return_value = publisher_latest_date
+        mock.return_value = publisher_latest_date_dict
         if test_download_exception:
             mock.side_effect = BaseException
             mock.return_value = (
@@ -132,8 +132,8 @@ def test_should_download_crossref_event_data(
 
 class TestGetNewDataDownloadStartDateFromCloudStorage:
     @pytest.mark.parametrize(
-        "publisher_latest_date, number_of_prv_days, "
-        "data_download_start_date",
+        "publisher_latest_date_dict, number_of_prv_days, "
+        "data_download_start_date_dict",
         [
             ({"A": "2019-10-23"}, 1, {"A": "2019-10-22"}),
             ({"A": "2016-09-23"}, 7, {"A": "2016-09-16"})
@@ -141,9 +141,9 @@ class TestGetNewDataDownloadStartDateFromCloudStorage:
     )
     def test_should_get_last_data_collection_date_from_cloud_storage(
         self,
-        download_s3_object_as_string_or_file_not_found_error_mock,
-        number_of_prv_days,
-        data_download_start_date,
+        download_s3_object_as_string_or_file_not_found_error_mock: MagicMock,
+        number_of_prv_days: int,
+        data_download_start_date_dict: dict,
     ):
         from_date = get_new_data_download_start_date_from_cloud_storage(
             "bucket", "object_key", number_of_prv_days
@@ -152,12 +152,12 @@ class TestGetNewDataDownloadStartDateFromCloudStorage:
             download_s3_object_as_string_or_file_not_found_error_mock
             .assert_called_with("bucket", "object_key")
         )
-        assert from_date == data_download_start_date
+        assert from_date == data_download_start_date_dict
 
     # parameter required because
     # download_s3_object_as_string_or_file_not_found_error_mock depends on it
     @pytest.mark.parametrize(
-        "publisher_latest_date",
+        "publisher_latest_date_dict",
         [{"A": "2019-10-23"}],
     )
     def test_should_return_empty_dict_if_state_file_not_found(

--- a/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
+++ b/tests/unit_test/crossref_event_data/etl_crossref_event_data_util_test.py
@@ -128,7 +128,6 @@ def test_should_download_crossref_event_data(
     )
 
 
-# pylint: disable=unused-argument
 class TestGetNewDataDownloadStartDateFromCloudStorage:
     @pytest.mark.parametrize(
         "publisher_latest_date, number_of_prv_days, "


### PR DESCRIPTION
We already had support for using a default date for a new prefix, but not for new state files.
This will add support for that.

(I made that change locally when I tried to retrieve data for bioRxiv)