### PR TITLE
do not update state for empy web api response

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -207,9 +207,13 @@ def generic_web_api_data_etl(
                 break
 
         load_written_data_to_bq(data_config, full_temp_file_location)
-        upload_latest_timestamp_as_pipeline_state(
-            data_config, latest_record_timestamp
-        )
+        if latest_record_timestamp:
+            LOGGER.info('updating state to: %r', latest_record_timestamp)
+            upload_latest_timestamp_as_pipeline_state(
+                data_config, latest_record_timestamp
+            )
+        else:
+            LOGGER.info('not updating state due to no latest record timestamp')
 
 
 def load_written_data_to_bq(


### PR DESCRIPTION
This will not update the state when the web api response is empty.
This may only be an issue when the initial state was empty, as it would then be None.
Whereas it would later just update the file with the previous state.

I encountered the issue when I tried to load Crossref Event data for a period that didn't have any date yet (and I expected it to then move the date forward)