### PR TITLE
reduced idle CPU usage by increasing min-file-process-interval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ x-airflow-env:
     - AIRFLOW__SMTP__SMTP_MAIL_FROM=do-no-reply@domain.com
     - AIRFLOW__API__AUTH_BACKEND=airflow.api.auth.backend.default
     - AIRFLOW__API__ENABLE_EXPERIMENTAL_API=True
-    - AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL=5
+    - AIRFLOW__SCHEDULER__FILE_PARSING_SORT_MODE=modified_time
+    - AIRFLOW__SCHEDULER__MIN_FILE_PROCESS_INTERVAL=600
     - AIRFLOW__WEBSERVER__SECRET_KEY='WmZHRmJwd1dCUEp6Xl4zVA=='
     - GOOGLE_APPLICATION_CREDENTIALS=/home/airflow/.config/gcloud/credentials.json
     - GOOGLE_CLOUD_PROJECT=elife-data-pipeline


### PR DESCRIPTION
The idle CPU usage was usually near 100%.
That is because it keeps updating the dags (by running `airflow scheduler - DagFileProcessor /opt/airflow/dags/elife_article_xml_import_pipeline.py`).

This is due to the `min-file-process-interval` set to `5` (every 5 seconds).

This can be avoided since Airflow 2.1.0, while still seeing DAG updates in development.

see
https://airflow.apache.org/docs/apache-airflow/stable/faq.html#when-there-are-a-lot-1000-of-dags-files-how-to-speed-up-parsing-of-new-files

> Change the file_parsing_sort_mode to modified_time, raise the min_file_process_interval to 600 (10 minutes), 6000 (100 minutes) or a higher value.
> 
> The dag parser will skip the min_file_process_interval check if a file is recently modified.
> 
> This might not work for case where the DAG is imported/created from a separate file. Example: dag_file.py that imports dag_loader.py where the actual logic of the DAG file is as shown below. In this case if dag_loader.py is updated but dag_file.py is not updated, the changes won’t be reflected until min_file_process_interval is reached since DAG Parser will look for modified time for dag_file.py file.

Tested changing a DAG (changed DAG id), and the change was reflected in the Airflow UI within a few seconds.

I think the caveat of not reflecting saving imported files shouldn't be an issue as we are mounting the files in development and those imports usually don't affect DAG definition itself. Sometimes they do, in those rare cases we could just save the DAG itself.