### PR TITLE
Web API: Added support for record timestamp in nested list

### DIFF
--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable, List, Optional, Sequence
 import dateparser
 
 from data_pipeline.generic_web_api.module_constants import ModuleConstant
+from data_pipeline.utils.collections import consume_iterable
 from data_pipeline.utils.data_store.s3_data_service import (
     download_s3_json_object,
 )
@@ -176,7 +177,7 @@ def iter_record_timestamp_from_record_list(
 def get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
     record_list: Iterable[Any],
     previous_latest_timestamp: Optional[datetime],
-    item_timestamp_key_path_from_item_root: Sequence[str]
+    item_timestamp_key_path_from_item_root: Optional[Sequence[str]]
 ) -> Optional[datetime]:
     latest_collected_record_timestamp_list: List[datetime] = []
     if previous_latest_timestamp:
@@ -188,6 +189,8 @@ def get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
                 item_timestamp_key_path_from_item_root
             )
         )
+    else:
+        consume_iterable(record_list)
     latest_timestamp = max(
         latest_collected_record_timestamp_list
     ) if latest_collected_record_timestamp_list else None

--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Iterable, Optional, Sequence
+from typing import Any, Iterable, List, Optional, Sequence
 import dateparser
 
 from data_pipeline.generic_web_api.module_constants import ModuleConstant
@@ -146,30 +146,64 @@ def filter_record_by_schema(record_object, record_object_schema):
         return new_list
 
 
-def get_latest_record_list_timestamp(
-        record_list, previous_latest_timestamp, data_config: WebApiConfig
-):
-    latest_collected_record_timestamp_list = [previous_latest_timestamp]
-
+def iter_record_timestamp_from_record_list(
+    record_list: Iterable[Any],
+    item_timestamp_key_path_from_item_root: Sequence[str]
+) -> Iterable[datetime]:
+    if not item_timestamp_key_path_from_item_root:
+        return
     for record in record_list:
-
-        if data_config.item_timestamp_key_path_from_item_root:
-            record_timestamp = parse_timestamp_from_str(
-                get_dict_values_from_path_as_list(
-                    record,
-                    data_config.item_timestamp_key_path_from_item_root
-                )
+        record_timestamp_str_or_list = get_dict_values_from_path_as_list(
+            record,
+            item_timestamp_key_path_from_item_root
+        )
+        if record_timestamp_str_or_list is None:
+            raise KeyError(
+                f'record timestamp not found, path={repr(item_timestamp_key_path_from_item_root)}'
+                f', record={repr(record)}'
             )
-            latest_collected_record_timestamp_list.append(record_timestamp)
-    latest_collected_record_timestamp_list = [
-        timestamp for
-        timestamp in latest_collected_record_timestamp_list
-        if timestamp
-    ]
+        LOGGER.debug('record_timestamp_str_or_list: %r', record_timestamp_str_or_list)
+        record_timestamp_str_list = (
+            record_timestamp_str_or_list if isinstance(record_timestamp_str_or_list, list)
+            else [record_timestamp_str_or_list]
+        )
+        for timestamp_str in record_timestamp_str_list:
+            timestamp = parse_timestamp_from_str(timestamp_str)
+            if timestamp:
+                yield timestamp
+
+
+def get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+    record_list: Iterable[Any],
+    previous_latest_timestamp: Optional[datetime],
+    item_timestamp_key_path_from_item_root: Sequence[str]
+) -> Optional[datetime]:
+    latest_collected_record_timestamp_list: List[datetime] = []
+    if previous_latest_timestamp:
+        latest_collected_record_timestamp_list.append(previous_latest_timestamp)
+    if item_timestamp_key_path_from_item_root:
+        latest_collected_record_timestamp_list.extend(
+            iter_record_timestamp_from_record_list(
+                record_list,
+                item_timestamp_key_path_from_item_root
+            )
+        )
     latest_timestamp = max(
         latest_collected_record_timestamp_list
     ) if latest_collected_record_timestamp_list else None
     return latest_timestamp
+
+
+def get_latest_record_list_timestamp(
+    record_list: Iterable[Any],
+    previous_latest_timestamp: Optional[datetime],
+    data_config: WebApiConfig
+):
+    return get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+        record_list,
+        previous_latest_timestamp=previous_latest_timestamp,
+        item_timestamp_key_path_from_item_root=data_config.item_timestamp_key_path_from_item_root
+    )
 
 
 def process_downloaded_data(

--- a/data_pipeline/utils/collections.py
+++ b/data_pipeline/utils/collections.py
@@ -1,6 +1,6 @@
 from itertools import islice
 from collections import deque
-from typing import Deque, Iterable, Type, TypeVar
+from typing import Any, Deque, Iterable, Type, TypeVar
 
 import logging
 
@@ -13,6 +13,11 @@ def chain_queue_and_iterable(queue: deque, iterable):
     while queue:
         yield queue.popleft()
     yield from iterable
+
+
+def consume_iterable(iterable: Iterable[Any]) -> None:
+    for _ in iterable:
+        pass
 
 
 def iter_batch_iterable(

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -1,6 +1,11 @@
+import pytest
+
 from data_pipeline.generic_web_api.transform_data import (
-    filter_record_by_schema
+    filter_record_by_schema,
+    get_dict_values_from_path_as_list,
+    get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root
 )
+from data_pipeline.utils.data_pipeline_timestamp import parse_timestamp_from_str
 
 
 TIMESTAMP_FIELD_NAME = 'ts'
@@ -9,6 +14,93 @@ TIMESTAMP_FIELD_SCHEMA = {
     'name': TIMESTAMP_FIELD_NAME,
     'type': 'TIMESTAMP'
 }
+
+TIMESTAMP_STR_1 = '2001-01-01T00:00:00+00:00'
+TIMESTAMP_STR_2 = '2001-01-02T00:00:00+00:00'
+TIMESTAMP_STR_3 = '2001-01-03T00:00:00+00:00'
+TIMESTAMP_STR_4 = '2001-01-04T00:00:00+00:00'
+
+
+class TestGetDictValuesFromPathAsList:
+    def test_should_return_value_from_dict_by_key(self):
+        assert get_dict_values_from_path_as_list(
+            {'key': 'value'},
+            ['key']
+        ) == 'value'
+
+    def test_should_return_value_from_nested_dict_by_key(self):
+        assert get_dict_values_from_path_as_list(
+            {'parent': {'key': 'value'}},
+            ['parent', 'key']
+        ) == 'value'
+
+    def test_should_return_values_from_list_by_key(self):
+        assert get_dict_values_from_path_as_list(
+            [{'key': 'value'}],
+            ['key']
+        ) == ['value']
+
+
+class TestGetLatestRecordListTimestampForItemTimestampKeyPathFromItemRoot:
+    def test_should_parse_and_return_latest_timestamp(self):
+        result = get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+            [
+                {'ts': TIMESTAMP_STR_2},
+                {'ts': TIMESTAMP_STR_4},
+                {'ts': TIMESTAMP_STR_3}
+            ],
+            previous_latest_timestamp=None,
+            item_timestamp_key_path_from_item_root=['ts']
+        )
+        assert result == parse_timestamp_from_str(TIMESTAMP_STR_4)
+
+    def test_should_return_previous_timestamp_if_latest(self):
+        result = get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+            [
+                {'ts': TIMESTAMP_STR_1},
+                {'ts': TIMESTAMP_STR_3},
+                {'ts': TIMESTAMP_STR_2}
+            ],
+            previous_latest_timestamp=parse_timestamp_from_str(TIMESTAMP_STR_4),
+            item_timestamp_key_path_from_item_root=['ts']
+        )
+        assert result == parse_timestamp_from_str(TIMESTAMP_STR_4)
+
+    def test_should_return_latest_timestamp_from_nested_list(self):
+        result = get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+            [{
+                'data': [
+                    {'ts': TIMESTAMP_STR_2},
+                    {'ts': TIMESTAMP_STR_4},
+                    {'ts': TIMESTAMP_STR_3}
+                ]
+            }],
+            previous_latest_timestamp=None,
+            item_timestamp_key_path_from_item_root=['data', 'ts']
+        )
+        assert result == parse_timestamp_from_str(TIMESTAMP_STR_4)
+
+    def test_should_ignore_empty_timestamp_str(self):
+        result = get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+            [{
+                'data': [
+                    {'ts': ''},
+                    {'ts': TIMESTAMP_STR_4},
+                    {'ts': TIMESTAMP_STR_3}
+                ]
+            }],
+            previous_latest_timestamp=None,
+            item_timestamp_key_path_from_item_root=['data', 'ts']
+        )
+        assert result == parse_timestamp_from_str(TIMESTAMP_STR_4)
+
+    def test_should_raise_error_if_key_was_not_found(self):
+        with pytest.raises(KeyError):
+            get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+                [{'ts': TIMESTAMP_STR_1}],
+                previous_latest_timestamp=None,
+                item_timestamp_key_path_from_item_root=['not_found']
+            )
 
 
 class TestFilterRecordBySchema:

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -94,6 +94,19 @@ class TestGetLatestRecordListTimestampForItemTimestampKeyPathFromItemRoot:
         )
         assert result == parse_timestamp_from_str(TIMESTAMP_STR_4)
 
+    def test_should_consume_iterable_even_without_item_timestamp_key_path_from_item_root(self):
+        # currently, the function is expected to consume the iterable in any case
+        # this will ensure the records are written to a file
+        record_list = [{'key': 'value'}]
+        record_iterable = iter(record_list)
+        get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(
+            record_iterable,
+            previous_latest_timestamp=None,
+            item_timestamp_key_path_from_item_root=None
+        )
+        remaining_items = list(record_iterable)
+        assert not remaining_items
+
     def test_should_raise_error_if_key_was_not_found(self):
         with pytest.raises(KeyError):
             get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root(


### PR DESCRIPTION
For the Twiiter API, it is possible to include extra data from linked ids.
In that case the response structure looks like:

```json
{
  "data": [...]
  "includes": {},
  "meta": {}
}
```

Whereas `data` is the list of Tweet data that contains for example an `author_id`.
Whereas `includes.users` could include the user summary of those author ids.

In that case it's easier to just dump the whole response to BigQuery (like we have now done for the EuropePMC response).
But then there is a single record.
We can then configure `itemTimestampKeyFromItemRoot` to be `["data", "created_at"]`, which previously would have failed as it is trying to parse a list of timestamp strings. Now it would be treated the same as if we extracted individual records from `data`.