### PR TITLE
bumps apache airflow from 2.4.2 to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.4.2-python3.8
+FROM apache/airflow:2.5.3-python3.8
 
 USER root
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[crypto,celery,postgres,jdbc,ssh]==2.4.2
+apache-airflow[crypto,celery,postgres,jdbc,ssh]==2.5.3
 apache-airflow-providers-amazon==7.3.0
 backoff==2.2.1
 bigquery-schema-generator==1.5


### PR DESCRIPTION
Dockerfile, bumps base image from 2.4.2 to 2.5.3.
deps, bumps apache airflow from 2.4.2 to 2.5.3