### PR TITLE
Removed restart always to not keep around SMTP server for longer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,6 @@ services:
             retries: 10
 
     smtp-server:
-        restart: always
         image:  namshi/smtp
 
     scheduler:


### PR DESCRIPTION
Whenever I start Airflow, I then have the SMTP server hanging around even after I am long finished with Airflow (and after system restarts).
This is due to the restart field.
It may make sense in some production scenarios, but in development it doesn't seem to be.