### PR TITLE
OpenSearch: Added timeout configuration

### DIFF
--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # The default timeout for OpenSearch operations in seconds
-DEFAULT_OPENSEARCH_TIMEOUT = 10.0
+DEFAULT_OPENSEARCH_TIMEOUT = 60.0
 
 
 @dataclass(frozen=True)

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -54,6 +54,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
             username=secrets['username'],
             password=secrets['password'],
             index_name=opensearch_target_config_dict['indexName'],
+            timeout=opensearch_target_config_dict.get('timeout', DEFAULT_OPENSEARCH_TIMEOUT),
             update_index_settings=opensearch_target_config_dict.get('updateIndexSettings', False),
             update_mappings=opensearch_target_config_dict.get('updateMappings', False),
             index_settings=opensearch_target_config_dict.get('indexSettings'),

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -13,6 +13,10 @@ from data_pipeline.utils.pipeline_config import (
 LOGGER = logging.getLogger(__name__)
 
 
+# The default timeout for OpenSearch operations in seconds
+DEFAULT_OPENSEARCH_TIMEOUT = 10.0
+
+
 @dataclass(frozen=True)
 class BigQueryToOpenSearchSourceConfig:
     bigquery: BigQuerySourceConfig
@@ -33,6 +37,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
     username: str = field(repr=False)
     password: str = field(repr=False)
     index_name: str
+    timeout: float = DEFAULT_OPENSEARCH_TIMEOUT
     update_index_settings: bool = False
     update_mappings: bool = False
     index_settings: Optional[dict] = None

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -68,6 +68,7 @@ def get_opensearch_client(opensearch_target_config: OpenSearchTargetConfig) -> O
             'port': opensearch_target_config.port
         }],
         http_auth=(opensearch_target_config.username, opensearch_target_config.password),
+        timeout=opensearch_target_config.timeout,
         use_ssl=True,
         verify_certs=opensearch_target_config.verify_certificates,
         ssl_show_warn=opensearch_target_config.verify_certificates

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -40,6 +40,7 @@ bigQueryToOpenSearch:
       openSearch:
         hostname: 'opensearch'
         port: 9200
+        timeout: 60
         # disable verification of certificates in development
         verifyCertificates: False
         secrets:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -21,7 +21,7 @@ bigQueryToOpenSearch:
               s2_response.provenance.response_timestamp AS data_hub_response_timestamp,
               s2_response.paperId AS s2_paper_id,
               europepmc_response.firstPublicationDate AS publication_date
-          FROM `elife-data-pipeline.de_proto.v_semantic_scholar_response` AS s2_response
+          FROM `elife-data-pipeline.prod.v_latest_semantic_scholar_response` AS s2_response
           LEFT JOIN `elife-data-pipeline.prod.v_latest_europepmc_preprint_servers_response` AS europepmc_response
               ON europepmc_response.doi = s2_response.externalIds.DOI
           -- adding ORDER BY and LIMIT for development only

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     DEFAULT_BATCH_SIZE,
+    DEFAULT_OPENSEARCH_TIMEOUT,
     BigQueryToOpenSearchConfig,
     OpenSearchTargetConfig
 )
@@ -100,6 +101,13 @@ class TestOpenSearchTargetConfig:
         )
         assert opensearch_target_config.hostname == OPENSEARCH_TARGET_CONFIG_DICT_1['hostname']
         assert opensearch_target_config.port == OPENSEARCH_TARGET_CONFIG_DICT_1['port']
+
+    def test_should_use_default_timeout(self):
+        assert 'timeout' not in OPENSEARCH_TARGET_CONFIG_DICT_1
+        opensearch_target_config = OpenSearchTargetConfig.from_dict(
+            OPENSEARCH_TARGET_CONFIG_DICT_1
+        )
+        assert opensearch_target_config.timeout == DEFAULT_OPENSEARCH_TIMEOUT
 
     def test_should_read_target_username_and_password_from_file_path_env_name(
         self

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -109,6 +109,13 @@ class TestOpenSearchTargetConfig:
         )
         assert opensearch_target_config.timeout == DEFAULT_OPENSEARCH_TIMEOUT
 
+    def test_should_read_timeout(self):
+        opensearch_target_config = OpenSearchTargetConfig.from_dict({
+            **OPENSEARCH_TARGET_CONFIG_DICT_1,
+            'timeout': 0.123
+        })
+        assert opensearch_target_config.timeout == 0.123
+
     def test_should_read_target_username_and_password_from_file_path_env_name(
         self
     ):

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -278,6 +278,15 @@ class TestGetOpenSearchClient:
             'port': OPENSEARCH_TARGET_CONFIG_1.port
         }]
 
+    def test_should_pass_in_timeout(
+        self,
+        opensearch_class_mock: MagicMock
+    ):
+        get_opensearch_client(BIGQUERY_TO_OPENSEARCH_CONFIG_1.target.opensearch)
+        opensearch_class_mock.assert_called()
+        _, kwargs = opensearch_class_mock.call_args
+        assert kwargs['timeout'] == BIGQUERY_TO_OPENSEARCH_CONFIG_1.target.opensearch.timeout
+
     def test_should_connect_via_ssl(
         self,
         opensearch_class_mock: MagicMock


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/763

It seemed valuable since we sometimes even received timeouts with a batch size of 100.
This also increases the default timeout to 60 seconds