### PR TITLE
Web API: ignore cursor matching previous cursor

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -384,8 +384,13 @@ def get_next_start_date(
     return from_timestamp, reset_page_or_offset_param
 
 
-def get_next_cursor_from_data(data, web_config: WebApiConfig):
+def get_next_cursor_from_data(
+    data,
+    web_config: WebApiConfig,
+    previous_cursor: Optional[str] = None
+):
     next_cursor = None
+    LOGGER.debug('previous_cursor: %r', previous_cursor)
 
     if web_config.url_builder.next_page_cursor:
         next_cursor = get_dict_values_from_path_as_list(

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -397,6 +397,8 @@ def get_next_cursor_from_data(
             data,
             web_config.next_page_cursor_key_path_from_response_root
         )
+        if next_cursor == previous_cursor:
+            next_cursor = None
     return next_cursor
 
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -175,7 +175,9 @@ def process_web_api_data_etl_batch(
                 prev_page_latest_timestamp=latest_record_timestamp
             )
             items_count = len(items_list)
-            cursor = get_next_cursor_from_data(page_data, data_config)
+            cursor = get_next_cursor_from_data(
+                page_data, data_config, previous_cursor=cursor
+            )
 
             from_date_to_advance, to_reset_page_or_offset_param = (
                 get_next_start_date(
@@ -387,7 +389,7 @@ def get_next_start_date(
 def get_next_cursor_from_data(
     data,
     web_config: WebApiConfig,
-    previous_cursor: Optional[str] = None
+    previous_cursor: Optional[str]
 ) -> Optional[str]:
     next_cursor = None
     LOGGER.debug('previous_cursor: %r', previous_cursor)

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -388,7 +388,7 @@ def get_next_cursor_from_data(
     data,
     web_config: WebApiConfig,
     previous_cursor: Optional[str] = None
-):
+) -> Optional[str]:
     next_cursor = None
     LOGGER.debug('previous_cursor: %r', previous_cursor)
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -391,17 +391,15 @@ def get_next_cursor_from_data(
     web_config: WebApiConfig,
     previous_cursor: Optional[str]
 ) -> Optional[str]:
-    next_cursor = None
     LOGGER.debug('previous_cursor: %r', previous_cursor)
-
     if web_config.url_builder.next_page_cursor:
         next_cursor = get_dict_values_from_path_as_list(
             data,
             web_config.next_page_cursor_key_path_from_response_root
         )
-        if next_cursor == previous_cursor:
-            next_cursor = None
-    return next_cursor
+        if next_cursor != previous_cursor:
+            return next_cursor
+    return None
 
 
 def get_items_list(page_data, web_config):

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -257,8 +257,7 @@ class TestNextCursor:
         'previous_cursor,next_cursor,expected_cursor',
         [
             (None, 'cursor1', 'cursor1'),
-            ('cursor0', 'cursor1', 'cursor1'),
-            ('cursor1', 'cursor1', None)
+            ('cursor0', 'cursor1', 'cursor1')
         ]
     )
     def test_should_get_cursor_value_when_in_data_and_cursor_param_in_config(
@@ -275,6 +274,14 @@ class TestNextCursor:
             data, data_config, previous_cursor=previous_cursor
         )
         assert actual_next_cursor == expected_cursor
+
+    def test_should_ignore_get_cursor_value_when_matching_previous_cursor(self):
+        data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
+        data = {'cursor_key1': 'cursor1'}
+        actual_next_cursor = get_next_cursor_from_data(
+            data, data_config, previous_cursor='cursor1'
+        )
+        assert actual_next_cursor is None
 
     def test_should_be_none_when_not_in_data_and_cursor_param_in_config(self):
         conf_dict = {

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -275,22 +275,13 @@ class TestNextCursor:
         )
         assert actual_next_cursor is None
 
-    def test_should_be_none_when_not_in_data_and_cursor_param_in_config(self):
-        conf_dict = {
-            'response': {
-                'nextPageCursorKeyFromResponseRoot': ['cursor_key1']
-            },
-            **WEB_API_CONFIG,
-        }
-        conf_dict['dataUrl']['configurableParameters'] = {
-            'nextPageCursorParameterName': 'cursor'
-        }
-
-        data_config = get_data_config(conf_dict)
-        data = {
-            'values': []
-        }
-        assert not get_next_cursor_from_data(data, data_config, previous_cursor=None)
+    def test_should_be_none_when_configured_but_not_in_data(self):
+        data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
+        data = {}
+        actual_next_cursor = get_next_cursor_from_data(
+            data, data_config, previous_cursor=None
+        )
+        assert actual_next_cursor is None
 
 
 class TestNextPage:

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, Sequence
 from unittest.mock import MagicMock, patch, ANY
 import pytest
 
@@ -232,6 +232,20 @@ class TestGetItemList:
             get_items_list(data, data_config)
 
 
+def _get_web_api_config_with_cursor_path(cursor_path: Sequence[str]) -> WebApiConfig:
+    conf_dict: dict = {
+        **WEB_API_CONFIG,
+        'response': {
+            'nextPageCursorKeyFromResponseRoot': cursor_path
+        }
+    }
+    conf_dict['dataUrl']['configurableParameters'] = {
+        'nextPageCursorParameterName': 'cursor'
+    }
+
+    return get_data_config(conf_dict)
+
+
 class TestNextCursor:
 
     def test_should_be_none_when_cursor_parameter_is_not_in_config(self):
@@ -255,17 +269,7 @@ class TestNextCursor:
     ):
         LOGGER.info('next_cursor=%r', next_cursor)
         cursor_path = ['cursor_key1', 'cursor_key2']
-        conf_dict: dict = {
-            **WEB_API_CONFIG,
-            'response': {
-                'nextPageCursorKeyFromResponseRoot': cursor_path
-            }
-        }
-        conf_dict['dataUrl']['configurableParameters'] = {
-            'nextPageCursorParameterName': 'cursor'
-        }
-
-        data_config = get_data_config(conf_dict)
+        data_config = _get_web_api_config_with_cursor_path(cursor_path)
         data = {cursor_path[0]: {cursor_path[1]: next_cursor}}
         actual_next_cursor = get_next_cursor_from_data(
             data, data_config, previous_cursor=previous_cursor

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -236,12 +236,13 @@ def _get_web_api_config_with_cursor_path(cursor_path: Sequence[str]) -> WebApiCo
         **WEB_API_CONFIG,
         'response': {
             'nextPageCursorKeyFromResponseRoot': cursor_path
+        },
+        'dataUrl': {
+            'configurableParameters': {
+                'nextPageCursorParameterName': 'cursor'
+            }
         }
     }
-    conf_dict['dataUrl']['configurableParameters'] = {
-        'nextPageCursorParameterName': 'cursor'
-    }
-
     return get_data_config(conf_dict)
 
 

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -240,13 +240,16 @@ class TestNextCursor:
         assert get_next_cursor_from_data(data, data_config) is None
 
     @pytest.mark.parametrize(
-        'next_cursor,expected_cursor',
+        'previous_cursor,next_cursor,expected_cursor',
         [
-            ('cursor1', 'cursor1')
+            (None, 'cursor1', 'cursor1'),
+            ('cursor0', 'cursor1', 'cursor1'),
+            ('cursor1', 'cursor1', None)
         ]
     )
     def test_should_get_cursor_value_when_in_data_and_cursor_param_in_config(
         self,
+        previous_cursor: Optional[str],
         next_cursor: Optional[str],
         expected_cursor: Optional[str]
     ):
@@ -267,7 +270,10 @@ class TestNextCursor:
             cursor_path[0]: {cursor_path[1]: next_cursor},
             'values': []
         }
-        assert get_next_cursor_from_data(data, data_config) == expected_cursor
+        actual_next_cursor = get_next_cursor_from_data(
+            data, data_config, previous_cursor=previous_cursor
+        )
+        assert actual_next_cursor == expected_cursor
 
     def test_should_be_none_when_not_in_data_and_cursor_param_in_config(self):
         conf_dict = {

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -266,10 +266,7 @@ class TestNextCursor:
         }
 
         data_config = get_data_config(conf_dict)
-        data = {
-            cursor_path[0]: {cursor_path[1]: next_cursor},
-            'values': []
-        }
+        data = {cursor_path[0]: {cursor_path[1]: next_cursor}}
         actual_next_cursor = get_next_cursor_from_data(
             data, data_config, previous_cursor=previous_cursor
         )

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -246,7 +246,6 @@ def _get_web_api_config_with_cursor_path(cursor_path: Sequence[str]) -> WebApiCo
 
 
 class TestNextCursor:
-
     def test_should_be_none_when_cursor_parameter_is_not_in_config(self):
         data_config = get_data_config(WEB_API_CONFIG)
         data = {'key': 'val', 'values': []}

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Optional, Sequence
+from typing import Sequence
 from unittest.mock import MagicMock, patch, ANY
 import pytest
 
@@ -16,7 +16,6 @@ from data_pipeline.generic_web_api.generic_web_api_data_etl import (
 )
 from data_pipeline.generic_web_api.generic_web_api_config import WebApiConfig
 from data_pipeline.generic_web_api.module_constants import ModuleConstant
-from data_pipeline.utils.collections import LOGGER
 
 
 @pytest.fixture(name='mock_upload_s3_object')
@@ -253,27 +252,21 @@ class TestNextCursor:
         data = {'key': 'val', 'values': []}
         assert get_next_cursor_from_data(data, data_config, previous_cursor=None) is None
 
-    @pytest.mark.parametrize(
-        'previous_cursor,next_cursor,expected_cursor',
-        [
-            (None, 'cursor1', 'cursor1'),
-            ('cursor0', 'cursor1', 'cursor1')
-        ]
-    )
-    def test_should_get_cursor_value_when_in_data_and_cursor_param_in_config(
-        self,
-        previous_cursor: Optional[str],
-        next_cursor: Optional[str],
-        expected_cursor: Optional[str]
-    ):
-        LOGGER.info('next_cursor=%r', next_cursor)
-        cursor_path = ['cursor_key1', 'cursor_key2']
-        data_config = _get_web_api_config_with_cursor_path(cursor_path)
-        data = {cursor_path[0]: {cursor_path[1]: next_cursor}}
+    def test_should_get_cursor_value_when_in_data_and_configured_without_previous_cursor(self):
+        data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
+        data = {'cursor_key1': 'cursor1'}
         actual_next_cursor = get_next_cursor_from_data(
-            data, data_config, previous_cursor=previous_cursor
+            data, data_config, previous_cursor=None
         )
-        assert actual_next_cursor == expected_cursor
+        assert actual_next_cursor == 'cursor1'
+
+    def test_should_get_cursor_value_when_in_data_and_configured_with_previous_cursor(self):
+        data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
+        data = {'cursor_key1': 'cursor1'}
+        actual_next_cursor = get_next_cursor_from_data(
+            data, data_config, previous_cursor='cursor0'
+        )
+        assert actual_next_cursor == 'cursor1'
 
     def test_should_ignore_get_cursor_value_when_matching_previous_cursor(self):
         data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -237,7 +237,7 @@ class TestNextCursor:
     def test_should_be_none_when_cursor_parameter_is_not_in_config(self):
         data_config = get_data_config(WEB_API_CONFIG)
         data = {'key': 'val', 'values': []}
-        assert get_next_cursor_from_data(data, data_config) is None
+        assert get_next_cursor_from_data(data, data_config, previous_cursor=None) is None
 
     @pytest.mark.parametrize(
         'previous_cursor,next_cursor,expected_cursor',
@@ -287,7 +287,7 @@ class TestNextCursor:
         data = {
             'values': []
         }
-        assert not get_next_cursor_from_data(data, data_config)
+        assert not get_next_cursor_from_data(data, data_config, previous_cursor=None)
 
 
 class TestNextPage:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/771

I want to use the Web API to retrieve all of the evaluated articles in EuropePMC.
On the last page, EuropePMC provides the same cursor as for the current page as the next cursor. That leads to an endless loop. We are already handling that in the bespoke EuropePMC pipeline. But the EuropePMC pipeline is geared towards processing date ranges (in this case we need to retrieve all of the articles every time, I believe).