### PR TITLE
Updated sample config to import from EuropePMC separately

### DIFF
--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -156,6 +156,7 @@ DEFAULT_BATCH_SIZE = 1000
 
 @dataclass(frozen=True)
 class BigQueryToOpenSearchConfig:
+    data_pipeline_id: str
     source: BigQueryToOpenSearchSourceConfig
     field_names_for: BigQueryToOpenSearchFieldNamesForConfig
     target: BigQueryToOpenSearchTargetConfig
@@ -165,6 +166,7 @@ class BigQueryToOpenSearchConfig:
     @staticmethod
     def _from_item_dict(item_config_dict: dict) -> 'BigQueryToOpenSearchConfig':
         return BigQueryToOpenSearchConfig(
+            data_pipeline_id=item_config_dict['dataPipelineId'],
             source=BigQueryToOpenSearchSourceConfig.from_dict(item_config_dict['source']),
             field_names_for=BigQueryToOpenSearchFieldNamesForConfig.from_dict(
                 item_config_dict['fieldNamesFor']

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -6,7 +6,8 @@ from typing import Optional, Sequence
 from data_pipeline.utils.pipeline_config import (
     BigQuerySourceConfig,
     StateFileConfig,
-    get_resolved_parameter_values_from_file_path_env_name
+    get_resolved_parameter_values_from_file_path_env_name,
+    parse_required_non_empty_key_path
 )
 
 
@@ -94,14 +95,18 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
 
 @dataclass(frozen=True)
 class BigQueryToOpenSearchFieldNamesForConfig:
-    id: str  # pylint: disable=invalid-name
-    timestamp: str
+    id_key_path: Sequence[str]
+    timestamp_key_path: Sequence[str]
 
     @staticmethod
     def from_dict(field_names_for_config_dict: dict) -> 'BigQueryToOpenSearchFieldNamesForConfig':
         return BigQueryToOpenSearchFieldNamesForConfig(
-            id=field_names_for_config_dict['id'],
-            timestamp=field_names_for_config_dict['timestamp']
+            id_key_path=parse_required_non_empty_key_path(
+                field_names_for_config_dict['id']
+            ),
+            timestamp_key_path=parse_required_non_empty_key_path(
+                field_names_for_config_dict['timestamp']
+            )
         )
 
 

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -226,7 +226,12 @@ def create_or_update_index_and_load_documents_into_opensearch(
         iter_batch_iterable(document_iterable, config.batch_size)
     ):
         batch_documents = list(batch_documents_iterable)
-        LOGGER.info('processing batch %d (%d documents)', 1 + index, len(batch_documents))
+        LOGGER.info(
+            '%s: processing batch %d (%d documents)',
+            config.data_pipeline_id,
+            1 + index,
+            len(batch_documents)
+        )
         load_documents_into_opensearch(
             batch_documents,
             client=client,

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import logging
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Sequence
 
 from opensearchpy import OpenSearch
 import opensearchpy
@@ -49,7 +49,7 @@ def iter_documents_from_bigquery(
     )
     wrapped_query = get_wrapped_query(
         bigquery_source_config.sql_query,
-        timestamp_field_name=config.field_names_for.timestamp,
+        timestamp_field_name='.'.join(config.field_names_for.timestamp_key_path),
         start_timestamp=start_timestamp
     )
     LOGGER.info('wrapped_query: %r', wrapped_query)
@@ -106,10 +106,18 @@ OPENSEARCH_BULK_DOCUMENT_FIELD_BY_OPERATION_MODE = {
 }
 
 
+def get_required_value_for_key_path(parent: dict, key_path: Sequence[str]) -> Any:
+    result: Any = parent
+    for key in key_path:
+        result = result.get(key)
+    assert result is not None
+    return result
+
+
 def get_opensearch_bulk_action_for_document(
     document: dict,
     index_name: str,
-    id_field_name: str,
+    id_key_path: Sequence[str],
     operation_mode: str,
     upsert: bool
 ) -> dict:
@@ -117,7 +125,7 @@ def get_opensearch_bulk_action_for_document(
     result: dict = {
         '_op_type': operation_mode,
         '_index': index_name,
-        '_id': document[id_field_name],
+        '_id': get_required_value_for_key_path(document, id_key_path),
         document_field_name: document
     }
     if upsert:
@@ -128,7 +136,7 @@ def get_opensearch_bulk_action_for_document(
 def iter_opensearch_bulk_action_for_documents(
     document_iterable: Iterable[dict],
     index_name: str,
-    id_field_name: str,
+    id_key_path: Sequence[str],
     operation_mode: str,
     upsert: bool = False
 ) -> Iterable[dict]:
@@ -136,7 +144,7 @@ def iter_opensearch_bulk_action_for_documents(
         get_opensearch_bulk_action_for_document(
             document,
             index_name=index_name,
-            id_field_name=id_field_name,
+            id_key_path=id_key_path,
             operation_mode=operation_mode,
             upsert=upsert
         )
@@ -155,7 +163,7 @@ def load_documents_into_opensearch(
     bulk_action_iterable = iter_opensearch_bulk_action_for_documents(
         document_iterable,
         index_name=opensearch_target_config.index_name,
-        id_field_name=field_names_for_config.id,
+        id_key_path=field_names_for_config.id_key_path,
         operation_mode=opensearch_target_config.operation_mode,
         upsert=opensearch_target_config.upsert
     )
@@ -196,9 +204,12 @@ def load_state_or_default_from_s3_for_config(
 
 def get_max_timestamp_from_documents(
     document_iterable: Iterable[dict],
-    timestamp_field_name: str
+    timestamp_key_path: Sequence[str]
 ) -> datetime:
-    return max(document[timestamp_field_name] for document in document_iterable)
+    return max(
+        get_required_value_for_key_path(document, timestamp_key_path)
+        for document in document_iterable
+    )
 
 
 def create_or_update_index_and_load_documents_into_opensearch(
@@ -225,7 +236,7 @@ def create_or_update_index_and_load_documents_into_opensearch(
         )
         timestamp = get_max_timestamp_from_documents(
             batch_documents,
-            timestamp_field_name=config.field_names_for.timestamp
+            timestamp_key_path=config.field_names_for.timestamp_key_path
         )
         LOGGER.info('updating state with: %r', timestamp)
         save_state_to_s3_for_config(

--- a/data_pipeline/utils/pipeline_config.py
+++ b/data_pipeline/utils/pipeline_config.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence, Type, TypeVar
+from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence, Type, TypeVar, Union
 
 from data_pipeline.utils.pipeline_file_io import get_yaml_file_as_dict, read_file_content
 
@@ -216,3 +216,22 @@ class MappingConfig:
             mapping=mapping,
             printable_mapping=printable_mapping
         )
+
+
+def parse_key_path(key_path: Optional[Union[str, Sequence[str]]]) -> Sequence[str]:
+    if isinstance(key_path, list):
+        return key_path
+    if isinstance(key_path, str):
+        return key_path.split('.')
+    if key_path is not None:
+        raise TypeError(f'unsupported type for key path: {type(key_path)}')
+    return []
+
+
+def parse_required_non_empty_key_path(
+    key_path: Optional[Union[str, Sequence[str]]]
+) -> Sequence[str]:
+    parsed_key_path = parse_key_path(key_path)
+    if not parsed_key_path:
+        raise ValueError('key path required')
+    return parsed_key_path

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -1,5 +1,5 @@
 bigQueryToOpenSearch:
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2_1
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -108,7 +108,7 @@ bigQueryToOpenSearch:
                     full_text_list:
                       type: "nested"
     batchSize: 100
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc_2
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -205,7 +205,7 @@ bigQueryToOpenSearch:
         operationMode: 'update'
         upsert: True
     batchSize: 100
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety_3
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -84,6 +84,14 @@ bigQueryToOpenSearch:
                         # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
                         ef_construction: 512
                         m: 16
+                europepmc:
+                  properties:
+                    author_list:
+                      type: "nested"
+                    version_list:
+                      type: "nested"
+                    full_text_list:
+                      type: "nested"
     batchSize: 100
   - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc_2
     source:
@@ -119,7 +127,7 @@ bigQueryToOpenSearch:
                               FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
                           ) AS affiliation_string_list
                       FROM UNNEST(europepmc_response.authorList.author) AS author
-                  ) AS author_list,
+                  ) AS authors,
 
                   ARRAY(
                       SELECT AS STRUCT

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -18,7 +18,10 @@ bigQueryToOpenSearch:
                   FROM UNNEST(s2_response.authors) AS author
                 ) AS author_list,
                 s2_response.embedding.vector AS specter_embedding_v1,
-                s2_response.tldr
+                STRUCT(
+                  s2_response.tldr.model AS model_id,
+                  s2_response.tldr.text
+                ) AS tldr
               ) AS s2
           FROM `elife-data-pipeline.prod.v_latest_semantic_scholar_response` AS s2_response
           -- for development: Select a few evaluated articles

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -6,6 +6,7 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
               s2_response.externalIds.DOI AS doi,
+
               STRUCT(
                 s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
                 s2_response.paperId AS paper_id,

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -86,17 +86,19 @@ bigQueryToOpenSearch:
                     author_list:
                       type: "nested"
                     specter_embedding_v1:
-                      type: "knn_vector"
-                      dimension: 768
-                      method:
-                        # Note: we need Lucene for filter support
-                        name: "hnsw"
-                        space_type: "l2"
-                        engine: "lucene"
-                        parameters:
-                          # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
-                          ef_construction: 512
-                          m: 16
+                      properties:
+                        vector:
+                          type: "knn_vector"
+                          dimension: 768
+                          method:
+                            # Note: we need Lucene for filter support
+                            name: "hnsw"
+                            space_type: "l2"
+                            engine: "lucene"
+                            parameters:
+                              # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+                              ef_construction: 512
+                              m: 16
                 europepmc:
                   properties:
                     author_list:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -1,5 +1,5 @@
 bigQueryToOpenSearch:
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_1
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_s2_1
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -16,14 +16,11 @@ bigQueryToOpenSearch:
               ) AS authors,
               s2_response.embedding.vector AS s2_specter_embedding_v1,
               s2_response.tldr,
-              s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
-              s2_response.provenance.request_timestamp AS data_hub_request_timestamp,
-              s2_response.provenance.response_timestamp AS data_hub_response_timestamp,
-              s2_response.paperId AS s2_paper_id,
-              europepmc_response.firstPublicationDate AS publication_date
+              s2_response.provenance.imported_timestamp AS s2_data_hub_imported_timestamp,
+              s2_response.provenance.request_timestamp AS s2_data_hub_request_timestamp,
+              s2_response.provenance.response_timestamp AS s2_data_hub_response_timestamp,
+              s2_response.paperId AS s2_paper_id
           FROM `elife-data-pipeline.prod.v_latest_semantic_scholar_response` AS s2_response
-          LEFT JOIN `elife-data-pipeline.prod.v_latest_europepmc_preprint_servers_response` AS europepmc_response
-              ON europepmc_response.doi = s2_response.externalIds.DOI
           -- for development: Select a few evaluated articles
           WHERE s2_response.externalIds.DOI IN (
             '10.1101/2020.07.24.219204', '10.1101/2023.03.30.534978', '10.1101/2022.08.24.504515'
@@ -87,7 +84,50 @@ bigQueryToOpenSearch:
                       ef_construction: 512
                       m: 16
     batchSize: 100
-  - dataPipelineId: bigquery_to_opensearch_data_pipeline_2
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc_2
+    source:
+      bigQuery:
+        projectName: 'elife-data-pipeline'
+        sqlQuery: |-
+          SELECT
+              europepmc_response.doi AS doi,
+              europepmc_response.provenance.imported_timestamp AS europepmc_data_hub_imported_timestamp
+              europepmc_response.firstPublicationDate AS publication_date,
+              europepmc_response.title_with_markup AS europepmc_title_with_markup,
+          FROM `elife-data-pipeline.prod.v_latest_europepmc_preprint_servers_response` AS europepmc_response
+          WHERE europepmc_response.doi IN (
+            '10.1101/2020.07.24.219204', '10.1101/2023.03.30.534978', '10.1101/2022.08.24.504515',
+            '10.1101/2022.09.28.509871'
+          )
+    fieldNamesFor:
+      id: doi
+      timestamp: europepmc_data_hub_imported_timestamp
+    state:
+      initialState:
+        startTimestamp: '2022-05-01+00:00'
+      stateFile:
+        bucketName: '{ENV}-elife-data-pipeline'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state.json'
+    target:
+      openSearch:
+        hostname: 'opensearch'
+        port: 9200
+        timeout: 60
+        # disable verification of certificates in development
+        verifyCertificates: False
+        secrets:
+          parametersFromFile:
+            - parameterName: username
+              filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
+            - parameterName: password
+              filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
+        indexName: 'dev_preprints_s2_v1'
+        updateIndexSettings: False
+        updateMappings: True
+        operationMode: 'update'
+        upsert: True
+    batchSize: 100
+  - dataPipelineId: bigquery_to_opensearch_data_pipeline_sciety_3
     source:
       bigQuery:
         projectName: 'elife-data-pipeline'
@@ -100,7 +140,8 @@ bigQueryToOpenSearch:
           WHERE event.normalized_event_name IN ('EvaluationRecorded', 'EvaluationPublicationRecorded')
             AND NOT event.is_deleted
             AND event.article_doi IN (
-              '10.1101/2020.07.24.219204', '10.1101/2023.03.30.534978', '10.1101/2022.08.24.504515'
+              '10.1101/2020.07.24.219204', '10.1101/2023.03.30.534978', '10.1101/2022.08.24.504515',
+              '10.1101/2022.09.28.509871'
             )
           GROUP BY event.article_doi
     fieldNamesFor:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -75,12 +75,6 @@ bigQueryToOpenSearch:
             properties:
                 doi:
                   type: "text"
-                title:
-                  type: "text"
-                abstract:
-                  type: "text"
-                publication_date:
-                  type: "date"
                 s2:
                   properties:
                     author_list:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -6,20 +6,20 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
               s2_response.externalIds.DOI AS doi,
-              s2_response.title,
-              s2_response.abstract,
-              ARRAY(
-                SELECT AS STRUCT
-                  author.name,
-                  author.authorId AS s2_author_id
-                FROM UNNEST(s2_response.authors) AS author
-              ) AS authors,
-              s2_response.embedding.vector AS s2_specter_embedding_v1,
-              s2_response.tldr,
-              s2_response.provenance.imported_timestamp AS s2_data_hub_imported_timestamp,
-              s2_response.provenance.request_timestamp AS s2_data_hub_request_timestamp,
-              s2_response.provenance.response_timestamp AS s2_data_hub_response_timestamp,
-              s2_response.paperId AS s2_paper_id
+              STRUCT(
+                s2_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
+                s2_response.paperId AS paper_id,
+                s2_response.title,
+                s2_response.abstract,
+                ARRAY(
+                  SELECT AS STRUCT
+                    author.name,
+                    author.authorId AS s2_author_id
+                  FROM UNNEST(s2_response.authors) AS author
+                ) AS authors,
+                s2_response.embedding.vector AS specter_embedding_v1,
+                s2_response.tldr
+              ) AS s2
           FROM `elife-data-pipeline.prod.v_latest_semantic_scholar_response` AS s2_response
           -- for development: Select a few evaluated articles
           WHERE s2_response.externalIds.DOI IN (
@@ -33,7 +33,7 @@ bigQueryToOpenSearch:
         startTimestamp: '2022-05-01+00:00'
       stateFile:
         bucketName: '{ENV}-elife-data-pipeline'
-        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state.json'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-s2.json'
     target:
       openSearch:
         hostname: 'opensearch'
@@ -47,7 +47,7 @@ bigQueryToOpenSearch:
               filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
             - parameterName: password
               filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
-        indexName: 'dev_preprints_s2_v1'
+        indexName: 'dev_preprints_v2'
         updateIndexSettings: False
         updateMappings: True
         operationMode: 'update'
@@ -71,18 +71,19 @@ bigQueryToOpenSearch:
                   type: "text"
                 publication_date:
                   type: "date"
-                s2_specter_embedding_v1:
-                  type: "knn_vector"
-                  dimension: 768
-                  method:
-                    # Note: we need Lucene for filter support
-                    name: "hnsw"
-                    space_type: "l2"
-                    engine: "lucene"
-                    parameters:
-                      # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
-                      ef_construction: 512
-                      m: 16
+                s2:
+                  specter_embedding_v1:
+                    type: "knn_vector"
+                    dimension: 768
+                    method:
+                      # Note: we need Lucene for filter support
+                      name: "hnsw"
+                      space_type: "l2"
+                      engine: "lucene"
+                      parameters:
+                        # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+                        ef_construction: 512
+                        m: 16
     batchSize: 100
   - dataPipelineId: bigquery_to_opensearch_data_pipeline_europepmc_2
     source:
@@ -91,9 +92,64 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
               europepmc_response.doi AS doi,
-              europepmc_response.provenance.imported_timestamp AS europepmc_data_hub_imported_timestamp
               europepmc_response.firstPublicationDate AS publication_date,
-              europepmc_response.title_with_markup AS europepmc_title_with_markup,
+
+              STRUCT(
+                  europepmc_response.source AS source,
+                  europepmc_response.provenance.imported_timestamp AS data_hub_imported_timestamp,
+                  europepmc_response.id AS id,
+                  europepmc_response.title_with_markup AS title_with_markup,
+                  europepmc_response.abstractText AS abstract_with_markup,
+                  europepmc_response.authorString AS author_string,
+                  europepmc_response.firstIndexDate AS first_index_date,
+                  europepmc_response.firstPublicationDate AS first_publication_date,
+                  europepmc_response.dateOfRevision AS revision_date,
+                  europepmc_response.language AS language,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          author.authorId AS author_id,
+                          author.collectiveName AS collective_name,
+                          author.firstName AS first_name,
+                          author.fullName AS full_name,
+                          author.initials,
+                          author.lastName AS last_name,
+                          ARRAY(
+                              SELECT affiliation
+                              FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
+                          ) AS affiliation_string_list
+                      FROM UNNEST(europepmc_response.authorList.author) AS author
+                  ) AS author_list,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          version.source,
+                          version.id,
+                          version.versionNumber AS version_number,
+                          version.firstPublishDate AS first_publication_date,
+                          ARRAY(
+                              SELECT publication_type
+                              FROM UNNEST(pubTypeList.pubType) AS publication_type
+                          ) AS publication_type_list
+                      FROM UNNEST(europepmc_response.versionList.version) AS version
+                  ) AS version_list,
+
+                  ARRAY(
+                      SELECT AS STRUCT
+                          full_text_info.availability,
+                          full_text_info.availabilityCode AS availability_code,
+                          full_text_info.documentStyle AS documentStyle,
+                          full_text_info.site AS site,
+                          full_text_info.url,
+                      FROM UNNEST(europepmc_response.fullTextUrlList.fullTextUrl) AS full_text_info
+                  ) AS full_text_list,
+
+                  ARRAY(
+                      SELECT keyword
+                      FROM UNNEST(europepmc_response.keywordList.keyword) AS keyword
+                  ) AS keyword_string_list
+              ) AS europepmc
+
           FROM `elife-data-pipeline.prod.v_latest_europepmc_preprint_servers_response` AS europepmc_response
           WHERE europepmc_response.doi IN (
             '10.1101/2020.07.24.219204', '10.1101/2023.03.30.534978', '10.1101/2022.08.24.504515',
@@ -107,7 +163,7 @@ bigQueryToOpenSearch:
         startTimestamp: '2022-05-01+00:00'
       stateFile:
         bucketName: '{ENV}-elife-data-pipeline'
-        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state.json'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-europepmc.json'
     target:
       openSearch:
         hostname: 'opensearch'
@@ -121,7 +177,7 @@ bigQueryToOpenSearch:
               filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
             - parameterName: password
               filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
-        indexName: 'dev_preprints_s2_v1'
+        indexName: 'dev_preprints_v2'
         updateIndexSettings: False
         updateMappings: True
         operationMode: 'update'
@@ -134,8 +190,10 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
             event.article_doi AS doi,
-            MAX(event_timestamp) AS last_event_timestamp,
-            COUNT(DISTINCT event.evaluation_locator) AS evaluation_count
+            STRUCT(
+              MAX(event_timestamp) AS last_event_timestamp,
+              COUNT(DISTINCT event.evaluation_locator) AS evaluation_count
+            ) AS sciety
           FROM `elife-data-pipeline.prod.v_sciety_event` AS event
           WHERE event.normalized_event_name IN ('EvaluationRecorded', 'EvaluationPublicationRecorded')
             AND NOT event.is_deleted
@@ -152,7 +210,7 @@ bigQueryToOpenSearch:
         startTimestamp: '2019-01-01+00:00'
       stateFile:
         bucketName: '{ENV}-elife-data-pipeline'
-        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-update-state.json'
+        objectName: 'airflow-config/bigquery-to-opensearch/{ENV}-state-sciety.json'
     target:
       openSearch:
         hostname: 'opensearch'
@@ -166,7 +224,7 @@ bigQueryToOpenSearch:
               filePathEnvName: OPENSEARCH_USERNAME_FILE_PATH
             - parameterName: password
               filePathEnvName: OPENSEARCH_PASSWORD_FILE_PATH
-        indexName: 'dev_preprints_s2_v1'
+        indexName: 'dev_preprints_v2'
         updateIndexSettings: False
         updateMappings: True
         operationMode: 'update'

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -113,7 +113,6 @@ bigQueryToOpenSearch:
         sqlQuery: |-
           SELECT
               europepmc_response.doi AS doi,
-              europepmc_response.firstPublicationDate AS publication_date,
 
               STRUCT(
                   europepmc_response.source AS source,

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -139,7 +139,7 @@ bigQueryToOpenSearch:
                               FROM UNNEST(author.authorAffiliationDetailsList.authorAffiliation) AS affiliation
                           ) AS affiliation_string_list
                       FROM UNNEST(europepmc_response.authorList.author) AS author
-                  ) AS authors,
+                  ) AS author_list,
 
                   ARRAY(
                       SELECT AS STRUCT

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -37,7 +37,7 @@ bigQueryToOpenSearch:
           )
     fieldNamesFor:
       id: doi
-      timestamp: data_hub_imported_timestamp
+      timestamp: s2.data_hub_imported_timestamp
     state:
       initialState:
         startTimestamp: '2022-05-01+00:00'
@@ -177,7 +177,7 @@ bigQueryToOpenSearch:
           )
     fieldNamesFor:
       id: doi
-      timestamp: europepmc_data_hub_imported_timestamp
+      timestamp: europepmc.data_hub_imported_timestamp
     state:
       initialState:
         startTimestamp: '2022-05-01+00:00'
@@ -224,7 +224,7 @@ bigQueryToOpenSearch:
           GROUP BY event.article_doi
     fieldNamesFor:
       id: doi
-      timestamp: last_event_timestamp
+      timestamp: sciety.last_event_timestamp
     state:
       initialState:
         startTimestamp: '2019-01-01+00:00'

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -16,7 +16,7 @@ bigQueryToOpenSearch:
                     author.name,
                     author.authorId AS s2_author_id
                   FROM UNNEST(s2_response.authors) AS author
-                ) AS authors,
+                ) AS author_list,
                 s2_response.embedding.vector AS specter_embedding_v1,
                 s2_response.tldr
               ) AS s2

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -73,6 +73,8 @@ bigQueryToOpenSearch:
                   type: "date"
                 s2:
                   properties:
+                    author_list:
+                      type: "nested"
                     specter_embedding_v1:
                       type: "knn_vector"
                       dimension: 768

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -11,13 +11,19 @@ bigQueryToOpenSearch:
                 s2_response.paperId AS paper_id,
                 s2_response.title,
                 s2_response.abstract,
+
                 ARRAY(
                   SELECT AS STRUCT
                     author.name,
                     author.authorId AS s2_author_id
                   FROM UNNEST(s2_response.authors) AS author
                 ) AS author_list,
-                s2_response.embedding.vector AS specter_embedding_v1,
+
+                STRUCT(
+                  s2_response.embedding.model AS model_id,
+                  s2_response.embedding.vector AS vector
+                ) AS specter_embedding_v1,
+
                 STRUCT(
                   s2_response.tldr.model AS model_id,
                   s2_response.tldr.text

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -72,18 +72,19 @@ bigQueryToOpenSearch:
                 publication_date:
                   type: "date"
                 s2:
-                  specter_embedding_v1:
-                    type: "knn_vector"
-                    dimension: 768
-                    method:
-                      # Note: we need Lucene for filter support
-                      name: "hnsw"
-                      space_type: "l2"
-                      engine: "lucene"
-                      parameters:
-                        # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
-                        ef_construction: 512
-                        m: 16
+                  properties:
+                    specter_embedding_v1:
+                      type: "knn_vector"
+                      dimension: 768
+                      method:
+                        # Note: we need Lucene for filter support
+                        name: "hnsw"
+                        space_type: "l2"
+                        engine: "lucene"
+                        parameters:
+                          # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
+                          ef_construction: 512
+                          m: 16
                 europepmc:
                   properties:
                     author_list:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -150,7 +150,7 @@ bigQueryToOpenSearch:
                           ARRAY(
                               SELECT publication_type
                               FROM UNNEST(pubTypeList.pubType) AS publication_type
-                          ) AS publication_type_list
+                          ) AS publication_type_string_list
                       FROM UNNEST(europepmc_response.versionList.version) AS version
                   ) AS version_list,
 

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -69,6 +69,7 @@ OPENSEARCH_TARGET_CONFIG_DICT_1 = {
 
 
 CONFIG_DICT_1: dict = {
+    'dataPipelineId': 'pipeline_1',
     'source': {'bigQuery': BIGQUERY_SOURCE_CONFIG_DICT_1},
     'fieldNamesFor': {
         'id': ID_FIELD_NAME,
@@ -213,6 +214,14 @@ class TestBigQueryToOpenSearchConfig:
             'bigQueryToOpenSearch': [CONFIG_DICT_1]
         }))
         assert len(config_list) == 1
+
+    def test_should_read_data_pipeline_id(self):
+        config_list = list(BigQueryToOpenSearchConfig.parse_config_list_from_dict({
+            'bigQueryToOpenSearch': [CONFIG_DICT_1]
+        }))
+        assert (
+            config_list[0].data_pipeline_id == CONFIG_DICT_1['dataPipelineId']
+        )
 
     def test_should_read_bigquery_source_config(self):
         config_list = list(BigQueryToOpenSearchConfig.parse_config_list_from_dict({

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -227,8 +227,8 @@ class TestBigQueryToOpenSearchConfig:
         config_list = list(BigQueryToOpenSearchConfig.parse_config_list_from_dict({
             'bigQueryToOpenSearch': [CONFIG_DICT_1]
         }))
-        assert config_list[0].field_names_for.id == ID_FIELD_NAME
-        assert config_list[0].field_names_for.timestamp == TIMESTAMP_FIELD_NAME
+        assert config_list[0].field_names_for.id_key_path == [ID_FIELD_NAME]
+        assert config_list[0].field_names_for.timestamp_key_path == [TIMESTAMP_FIELD_NAME]
 
     def test_should_use_default_batch_size_for_config(self):
         assert 'batchSize' not in CONFIG_DICT_1

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -62,8 +62,8 @@ BIGQUERY_TO_OPENSEARCH_CONFIG_1 = BigQueryToOpenSearchConfig(
         )
     ),
     field_names_for=BigQueryToOpenSearchFieldNamesForConfig(
-        id=ID_FIELD_NAME,
-        timestamp=TIMESTAMP_FIELD_NAME
+        id_key_path=[ID_FIELD_NAME],
+        timestamp_key_path=[TIMESTAMP_FIELD_NAME]
     ),
     target=BigQueryToOpenSearchTargetConfig(
         opensearch=OpenSearchTargetConfig(
@@ -471,7 +471,7 @@ class TestIterOpenSearchBulkActionForDocuments:
         bulk_actions = list(iter_opensearch_bulk_action_for_documents(
             [DOCUMENT_1],
             index_name='index_1',
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OpenSearchOperationModes.INDEX
         ))
         assert bulk_actions == [{
@@ -485,7 +485,7 @@ class TestIterOpenSearchBulkActionForDocuments:
         bulk_actions = list(iter_opensearch_bulk_action_for_documents(
             [DOCUMENT_1],
             index_name='index_1',
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OpenSearchOperationModes.CREATE
         ))
         assert bulk_actions == [{
@@ -499,7 +499,7 @@ class TestIterOpenSearchBulkActionForDocuments:
         bulk_actions = list(iter_opensearch_bulk_action_for_documents(
             [DOCUMENT_1],
             index_name='index_1',
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OpenSearchOperationModes.UPDATE
         ))
         assert bulk_actions == [{
@@ -513,7 +513,7 @@ class TestIterOpenSearchBulkActionForDocuments:
         bulk_actions = list(iter_opensearch_bulk_action_for_documents(
             [DOCUMENT_1],
             index_name='index_1',
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OpenSearchOperationModes.UPDATE,
             upsert=True
         ))
@@ -542,7 +542,7 @@ class TestLoadDocumentsIntoOpenSearch:
         iter_opensearch_bulk_action_for_documents_mock.assert_called_with(
             [DOCUMENT_1],
             index_name=OPENSEARCH_TARGET_CONFIG_1.index_name,
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OPENSEARCH_TARGET_CONFIG_1.operation_mode,
             upsert=OPENSEARCH_TARGET_CONFIG_1.upsert
         )
@@ -573,7 +573,7 @@ class TestLoadDocumentsIntoOpenSearch:
         expected_bulk_actions = list(iter_opensearch_bulk_action_for_documents(
             [DOCUMENT_1],
             index_name=OPENSEARCH_TARGET_CONFIG_1.index_name,
-            id_field_name=ID_FIELD_NAME,
+            id_key_path=[ID_FIELD_NAME],
             operation_mode=OPENSEARCH_TARGET_CONFIG_1.operation_mode,
             upsert=OPENSEARCH_TARGET_CONFIG_1.upsert
         ))

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -55,6 +55,7 @@ QUERY_1 = 'query 1'
 
 
 BIGQUERY_TO_OPENSEARCH_CONFIG_1 = BigQueryToOpenSearchConfig(
+    data_pipeline_id='pipeline_1',
     source=BigQueryToOpenSearchSourceConfig(
         bigquery=BigQuerySourceConfig(
             project_name='project1',

--- a/tests/unit_test/utils/pipeline_config_test.py
+++ b/tests/unit_test/utils/pipeline_config_test.py
@@ -10,6 +10,8 @@ from data_pipeline.utils.pipeline_config import (
     MappingConfig,
     StateFileConfig,
     get_resolved_parameter_values_from_file_path_env_name,
+    parse_key_path,
+    parse_required_non_empty_key_path,
     str_to_bool,
     get_environment_variable_value
 )
@@ -187,3 +189,33 @@ class TestMappingConfig:
         assert config.printable_mapping == {KEY_1: SECRET_VALUE_PLACEHOLDER}
         assert VALUE_1 not in str(config)
         assert VALUE_1 not in repr(config)
+
+
+class TestParseKeyPath:
+    def test_should_return_empty_list_for_none(self):
+        assert parse_key_path(None) == []
+
+    def test_should_return_passed_in_list_if_list(self):
+        assert parse_key_path(['parent', 'child']) == ['parent', 'child']
+
+    def test_should_split_string_path_by_dot(self):
+        assert parse_key_path('parent.child') == ['parent', 'child']
+
+    def test_should_raise_error_if_other_type(self):
+        with pytest.raises(TypeError):
+            parse_key_path({'set'})
+
+
+class TestParseRequiredNonEmptyKeyPath:
+    def test_should_raise_error_for_none(self):
+        with pytest.raises(ValueError):
+            parse_required_non_empty_key_path(None)
+
+    def test_should_raise_error_for_empty_list(self):
+        with pytest.raises(ValueError):
+            parse_required_non_empty_key_path([])
+
+    def test_should_return_passed_in_list_if_not_empty(self):
+        assert parse_required_non_empty_key_path(
+            ['parent', 'child']
+        ) == ['parent', 'child']


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794

I thought it is still useful to update the example config too.
I also added `10.1101/2022.09.28.509871` which isn't available in S2.

Some potential future improvement:

- rename `fieldNamesFor` to `keyPathsFor`
- introduce `KeyPath` class
- move index settings out of pipeline config (e.g. to top level)