### PR TITLE
Added imported timestamp to data_hub_bigquery_views_pipeline_log

### DIFF
--- a/data_pipeline/bigquery_views/pipeline.py
+++ b/data_pipeline/bigquery_views/pipeline.py
@@ -10,6 +10,7 @@ from bigquery_views_manager.materialize_views import (
     materialize_views,
     MaterializeViewListResult
 )
+from data_pipeline.utils.data_pipeline_timestamp import get_current_timestamp
 from data_pipeline.utils.data_store.bq_data_service import (
     load_given_json_list_data_from_tempdir_to_bq
 )
@@ -42,7 +43,14 @@ def get_client(config: BigQueryViewsConfig) -> bigquery.Client:
 def get_json_list_for_materialize_views_log(
     materialize_views_log: MaterializeViewListResult
 ) -> Sequence[dict]:
-    return remove_key_with_null_value(asdict(materialize_views_log)['result_list'])
+    data_hub_imported_timestamp = get_current_timestamp()
+    return [
+        {
+            **record,
+            'data_hub_imported_timestamp': data_hub_imported_timestamp
+        }
+        for record in remove_key_with_null_value(asdict(materialize_views_log)['result_list'])
+    ]
 
 
 def materialize_bigquery_views(config: BigQueryViewsConfig):

--- a/data_pipeline/bigquery_views/pipeline.py
+++ b/data_pipeline/bigquery_views/pipeline.py
@@ -47,7 +47,7 @@ def get_json_list_for_materialize_views_log(
     return [
         {
             **record,
-            'data_hub_imported_timestamp': data_hub_imported_timestamp
+            'data_hub_imported_timestamp': data_hub_imported_timestamp.isoformat()
         }
         for record in remove_key_with_null_value(asdict(materialize_views_log)['result_list'])
     ]

--- a/tests/unit_test/bigquery_views/pipeline_test.py
+++ b/tests/unit_test/bigquery_views/pipeline_test.py
@@ -157,7 +157,7 @@ class TestGetJsonListForMaterializeViewsLog:
             )
         )
         assert result == [{
-            'data_hub_imported_timestamp': ANY,
+            'data_hub_imported_timestamp': CURRENT_TIMESTAMP.isoformat(),
             'source_dataset': 'source_dataset_1',
             'source_view_name': 'source_view_name_1',
             'destination_dataset': 'destination_dataset_1',

--- a/tests/unit_test/bigquery_views/pipeline_test.py
+++ b/tests/unit_test/bigquery_views/pipeline_test.py
@@ -1,7 +1,8 @@
 import dataclasses
+from datetime import datetime
 import logging
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, patch, MagicMock
 from typing import Iterable
 
 import pytest
@@ -31,6 +32,8 @@ LOGGER = logging.getLogger(__name__)
 
 GCP_PROJECT_1 = 'gcp-project-1'
 
+CURRENT_TIMESTAMP = datetime.fromisoformat('2023-01-02T03:04:05+00:00')
+
 MATCHING_DATASET_1 = 'matching_dataset1'
 OTHER_DATASET_1 = 'other_dataset1'
 OUTPUT_DATASET_1 = 'output_dataset1'
@@ -48,6 +51,13 @@ MATERIALIZE_VIEW_RESULT_1 = MaterializeViewResult(
     slot_millis=10,
     total_bytes_billed=10
 )
+
+
+@pytest.fixture(name='get_current_timestamp_mock', autouse=True)
+def _get_current_timestamp_mock() -> Iterable[MagicMock]:
+    with patch.object(target_module, 'get_current_timestamp') as mock:
+        mock.return_value = CURRENT_TIMESTAMP
+        yield mock
 
 
 @pytest.fixture(name='bigquery', autouse=True)
@@ -147,6 +157,7 @@ class TestGetJsonListForMaterializeViewsLog:
             )
         )
         assert result == [{
+            'data_hub_imported_timestamp': ANY,
             'source_dataset': 'source_dataset_1',
             'source_view_name': 'source_view_name_1',
             'destination_dataset': 'destination_dataset_1',

--- a/tests/unit_test/bigquery_views/pipeline_test.py
+++ b/tests/unit_test/bigquery_views/pipeline_test.py
@@ -2,7 +2,7 @@ import dataclasses
 from datetime import datetime
 import logging
 from pathlib import Path
-from unittest.mock import ANY, patch, MagicMock
+from unittest.mock import patch, MagicMock
 from typing import Iterable
 
 import pytest


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/789
related to https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1313

A timestamp is required to see change over time