### PR TITLE
Dev: Allow Web API config path to be passed in via env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ x-airflow-env:
     - SURVEYMONKEY_DATA_CONFIG_FILE_PATH=/home/airflow/sample_data_config/surveymonkey/surveymonkey-data-pipeline.config.yaml
     - SPREADSHEET_CONFIG_FILE_PATH=/home/airflow/sample_data_config/google-spreadsheet/spreadsheet-data-pipeline.config.yaml
     - S3_CSV_CONFIG_FILE_PATH=/home/airflow/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
-    - WEB_API_CONFIG_FILE_PATH=/home/airflow/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+    - WEB_API_CONFIG_FILE_PATH=${WEB_API_CONFIG_FILE_PATH:-/home/airflow/sample_data_config/web-api/web-api-data-pipeline.config.yaml}
     - CIVICRM_EMAIL_DATA_CONFIG_FILE_PATH=/home/airflow/sample_data_config/civicrm-email/civicrm-email-report-data-pipeline.config.yaml
     - CIVICRM_API_KEY_FILE_PATH=path-to-civi-api-key
     - CIVICRM_SITE_KEY_FILE_PATH=path-to-civi-site-key


### PR DESCRIPTION
Before starting Airflow, the config path can be set via the `WEB_API_CONFIG_FILE_PATH` env variable without changing a file.

e.g.

```bash
export WEB_API_CONFIG_FILE_PATH=/home/airflow/sample_data_config/web-api/local-test-web-api-s2-embeddings.config.yaml

make airflow-initdb airflow-start
```