### PR TITLE
Web API: measure memory usage

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -30,6 +30,7 @@ from data_pipeline.utils.data_store.bq_data_service import (
 from data_pipeline.utils.json import remove_key_with_null_value
 from data_pipeline.utils.pipeline_file_io import iter_write_jsonl_to_file
 from data_pipeline.utils.pipeline_utils import iter_dict_for_bigquery_include_exclude_source_config
+from data_pipeline.utils.text import format_byte_count
 from data_pipeline.utils.web_api import requests_retry_session
 
 from data_pipeline.generic_web_api.generic_web_api_config import (
@@ -128,9 +129,9 @@ def get_data_single_page(
             )
         parsed_response_size = objsize.get_deep_size(json_resp)
         LOGGER.info(
-            'Response size (bytes): %s, parsed: %s',
-            f'{len(resp):,}',
-            f'{parsed_response_size:,}'
+            'Response size: %s, parsed: %s',
+            format_byte_count(len(resp)),
+            format_byte_count(parsed_response_size)
         )
     return json_resp
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -117,6 +117,7 @@ def get_data_single_page(
         )
         session_response.raise_for_status()
         resp = session_response.content
+        LOGGER.info('Response size (bytes): %s', f'{len(resp):,}')
         try:
             json_resp = json.loads(resp)
         except JSONDecodeError:

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -7,6 +7,8 @@ import json
 from json.decoder import JSONDecodeError
 from typing import Any, Iterable, Optional, Tuple, TypeVar, cast
 
+import objsize
+
 from botocore.exceptions import ClientError
 
 from data_pipeline.generic_web_api.transform_data import (
@@ -117,7 +119,6 @@ def get_data_single_page(
         )
         session_response.raise_for_status()
         resp = session_response.content
-        LOGGER.info('Response size (bytes): %s', f'{len(resp):,}')
         try:
             json_resp = json.loads(resp)
         except JSONDecodeError:
@@ -125,6 +126,12 @@ def get_data_single_page(
             json_resp = get_newline_delimited_json_string_as_json_list(
                 resp.decode("utf-8")
             )
+        parsed_response_size = objsize.get_deep_size(json_resp)
+        LOGGER.info(
+            'Response size (bytes): %s, parsed: %s',
+            f'{len(resp):,}',
+            f'{parsed_response_size:,}'
+        )
     return json_resp
 
 

--- a/data_pipeline/utils/text.py
+++ b/data_pipeline/utils/text.py
@@ -1,0 +1,2 @@
+def format_byte_count(byte_count: int) -> str:
+    return f'{byte_count:,} bytes'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ botocore==1.27.59
 cattrs==23.1.2
 cloudpickle==2.2.1
 dateparser==1.1.8
+objsize==0.7.0
 regex==2023.10.3
 fsspec==2022.8.2
 lxml>=4.8.0, <4.10.0

--- a/tests/unit_test/utils/text_test.py
+++ b/tests/unit_test/utils/text_test.py
@@ -1,0 +1,6 @@
+from data_pipeline.utils.text import format_byte_count
+
+
+class TestFormatByteCount:
+    def test_should_format_byte_count_with_thousands_separator(self):
+        assert format_byte_count(1234568) == '1,234,568 bytes'


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/461 and https://github.com/elifesciences/data-hub-issues/issues/810

For the Web API, the response for a single page should have most impact on he variation in memory usage.
That is why I thought logging of the response size and how much memory it uses when parsed would be useful to see difference across Web APIs.
(It's not the total memory usage of the process of course)