### PR TITLE
Fixed dev-unittest by moving default to config module

### DIFF
--- a/dags/s3_csv_import_pipeline.py
+++ b/dags/s3_csv_import_pipeline.py
@@ -9,7 +9,11 @@ from typing import Optional, Sequence
 import airflow
 from airflow.exceptions import AirflowSkipException
 
-from data_pipeline.s3_csv_data.s3_csv_config import MultiS3CsvConfig, S3BaseCsvConfig
+from data_pipeline.s3_csv_data.s3_csv_config import (
+    DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE,
+    MultiS3CsvConfig,
+    S3BaseCsvConfig
+)
 from data_pipeline.s3_csv_data.s3_csv_config_typing import S3CsvConfigDict
 from data_pipeline.s3_csv_data.s3_csv_etl import (
     transform_load_data,
@@ -38,8 +42,6 @@ LOGGER = logging.getLogger(__name__)
 INITIAL_S3_FILE_LAST_MODIFIED_DATE_ENV_NAME = (
     "INITIAL_S3_FILE_LAST_MODIFIED_DATE"
 )
-DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE = "2019-04-11 21:10:13"
-
 
 S3_CSV_SCHEDULE_INTERVAL_ENV_NAME = (
     "S3_CSV_SCHEDULE_INTERVAL"

--- a/data_pipeline/s3_csv_data/s3_csv_config.py
+++ b/data_pipeline/s3_csv_data/s3_csv_config.py
@@ -7,6 +7,9 @@ from data_pipeline.utils.pipeline_config import (
 )
 
 
+DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE = "2019-04-11 21:10:13"
+
+
 class MultiS3CsvConfig:
     def __init__(self,
                  multi_s3_csv_config: dict,

--- a/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
@@ -18,12 +18,10 @@ from data_pipeline.s3_csv_data.s3_csv_etl import (
     merge_record_with_metadata
 )
 from data_pipeline.s3_csv_data.s3_csv_config import (
+    DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE,
     S3BaseCsvConfig
 )
 from data_pipeline.utils.record_processing import DEFAULT_PROCESSING_STEPS
-from dags.s3_csv_import_pipeline import (
-    DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE
-)
 
 
 # pylint: disable=trailing-whitespace


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/810 Follow-up to #1348

This wasn't an issue when running via Docker because we would define the environment variables. In any case we shouldn't depend on "dags" as part of the unit tests.

<details>
<summary>error logs</summary>

```text
________________________________ ERROR collecting unit_test/s3_csv_data/s3_csv_etl_test.py _________________________________
venv/lib/python3.8/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
venv/lib/python3.8/site-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
venv/lib/python3.8/site-packages/_pytest/python.py:531: in collect
    self._inject_setup_module_fixture()
venv/lib/python3.8/site-packages/_pytest/python.py:545: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
venv/lib/python3.8/site-packages/_pytest/python.py:310: in obj
    self._obj = obj = self._getobj()
venv/lib/python3.8/site-packages/_pytest/python.py:528: in _getobj
    return self._importtestmodule()
venv/lib/python3.8/site-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
venv/lib/python3.8/site-packages/_pytest/pathlib.py:567: in import_path
    importlib.import_module(module_name)
../../../../apps/pyenv/versions/3.8.7/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
<frozen importlib._bootstrap>:975: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:671: in _load_unlocked
    ???
venv/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
tests/unit_test/s3_csv_data/s3_csv_etl_test.py:24: in <module>
    from dags.s3_csv_import_pipeline import (
dags/s3_csv_import_pipeline.py:160: in <module>
    DAGS = create_csv_pipeline_dags(default_schedule=get_default_schedule())
dags/s3_csv_import_pipeline.py:124: in create_csv_pipeline_dags
    multi_csv_pipeline_config = get_multi_csv_pipeline_config()
dags/s3_csv_import_pipeline.py:53: in get_multi_csv_pipeline_config
    return get_pipeline_config_for_env_name_and_config_parser(
data_pipeline/utils/pipeline_config.py:267: in get_pipeline_config_for_env_name_and_config_parser
    conf_file_path = os.environ[config_file_path_env_name]
../../../../apps/pyenv/versions/3.8.7/lib/python3.8/os.py:675: in __getitem__
    raise KeyError(key) from None
E   KeyError: 'S3_CSV_CONFIG_FILE_PATH'
----------------------------------------------------- Captured stdout ------------------------------------------------------
[2023-12-04T23:12:43.046+0000] {pipeline_config.py:266} INFO - deployment_env: ci
================================================= short test summary info ==================================================
ERROR tests/unit_test/s3_csv_data/s3_csv_etl_test.py - KeyError: 'S3_CSV_CONFIG_FILE_PATH'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================== 1 error in 5.44s =====================================================
```
</details>