### PR TITLE
Added "parse_json_value" processing functions for CSV pipeline

### DIFF
--- a/data_pipeline/utils/record_processing.py
+++ b/data_pipeline/utils/record_processing.py
@@ -1,4 +1,5 @@
 import html
+import json
 from typing import List
 
 DEFAULT_PROCESSING_STEPS = ['strip_quotes']
@@ -49,7 +50,14 @@ def strip_quotes(val):
     return n_val
 
 
+def parse_json_value(value: str):
+    if isinstance(value, str) and value.startswith('{') and value.endswith('}'):
+        return json.loads(value)
+    return value
+
+
 FUNCTION_NAME_MAPPING = {
     "html_unescape": unescape_html_escaped_values_in_string,
-    "strip_quotes": strip_quotes
+    "strip_quotes": strip_quotes,
+    "parse_json_value": parse_json_value
 }

--- a/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
+++ b/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
@@ -4,6 +4,8 @@ stateFile:
   defaultBucketName: ci-elife-data-pipeline
   defaultSystemGeneratedObjectPrefix: "airflow-config/{ENV}-s3-csv/state/s3-csv"
 s3Csv:
+  # Note: the first configuration is used by the end2end test
+
   #- bucketName: elife-ejp-ftp
   #  objectKeyPattern:
   #    - ejp_query_tool_query_id_15a* # the pattern of the s3 object to be monitored
@@ -55,3 +57,21 @@ s3Csv:
         metadataLineIndex: 1
     recordProcessingSteps: # html
       - html_unescape
+
+
+  # The following configuration items will not be used by end2end test:
+
+  - dataPipelineId: s3_csv_test_sciety_events
+    bucketName: sciety-data-extractions
+    objectKeyPattern:
+      - events-from-cronjob.csv
+    headerLineIndex: 0
+    dataValuesStartLineIndex: 1
+    datasetName: "{ENV}"
+    tableName: 's3_csv_test_sciety_event'
+    tableWriteAppend: False
+    stateFile:
+      bucketName: ci-elife-data-pipeline
+      objectName: "airflow_test/state/s3-csv/state-sciety-events.json"
+    recordProcessingSteps:
+      - parse_json_value

--- a/tests/unit_test/utils/record_processing_test.py
+++ b/tests/unit_test/utils/record_processing_test.py
@@ -1,4 +1,5 @@
 from data_pipeline.utils.record_processing import (
+    parse_json_value,
     unescape_html_escaped_values_in_string,
     strip_quotes,
     process_record_values
@@ -34,6 +35,22 @@ class TestStripQuotes:
             for val in test_data
         ]
         assert result == expected_result
+
+
+class TestParseJsonValue:
+    def test_should_return_none_if_passed_in_value_is_none(self):
+        assert parse_json_value(None) is None
+
+    def test_should_return_passed_in_value_if_not_string(self):
+        assert parse_json_value(123) == 123
+
+    def test_should_return_passed_in_value_if_not_starting_and_ending_with_curly_bracket(self):
+        assert parse_json_value('test') == 'test'
+        assert parse_json_value('{test') == '{test'
+        assert parse_json_value('test}') == 'test}'
+
+    def test_should_return_parse_json_value_if_starting_and_ending_with_curly_bracket(self):
+        assert parse_json_value('{"key": "value"}') == {'key': 'value'}
 
 
 class TestProcessRecordValues:

--- a/tests/unit_test/utils/record_processing_test.py
+++ b/tests/unit_test/utils/record_processing_test.py
@@ -5,53 +5,55 @@ from data_pipeline.utils.record_processing import (
 )
 
 
-def test_should_unescape_html_should_return_unescaped_values():
-    test_data = ["&quot;", "&amp;", "&lt", "&gt"]
-    expected_result = ["\"", "&", "<", ">"]
-    result = [
-        unescape_html_escaped_values_in_string(val)
-        for val in test_data
-    ]
-    assert result == expected_result
+class TestUnescapeHtmlEscapedValuesInString:
+    def test_should_unescape_html_should_return_unescaped_values(self):
+        test_data = ["&quot;", "&amp;", "&lt", "&gt"]
+        expected_result = ["\"", "&", "<", ">"]
+        result = [
+            unescape_html_escaped_values_in_string(val)
+            for val in test_data
+        ]
+        assert result == expected_result
 
 
-def test_should_strip_when_quote_is_at_both_ends():
-    test_data = [" 'test1' ", "\"test2\""]
-    expected_result = ["test1", "test2"]
-    result = [
-        strip_quotes(val)
-        for val in test_data
-    ]
-    assert result == expected_result
+class TestStripQuotes:
+    def test_should_strip_when_quote_is_at_both_ends(self):
+        test_data = [" 'test1' ", "\"test2\""]
+        expected_result = ["test1", "test2"]
+        result = [
+            strip_quotes(val)
+            for val in test_data
+        ]
+        assert result == expected_result
+
+    def test_should_not_strip_when_quote_is_at_only_one_end(self):
+        test_data = [" 'test1 ", "test2\""]
+        expected_result = ["'test1", "test2\""]
+        result = [
+            strip_quotes(val)
+            for val in test_data
+        ]
+        assert result == expected_result
 
 
-def test_should_not_strip_when_quote_is_at_only_one_end():
-    test_data = [" 'test1 ", "test2\""]
-    expected_result = ["'test1", "test2\""]
-    result = [
-        strip_quotes(val)
-        for val in test_data
-    ]
-    assert result == expected_result
-
-
-def test_should_unescape_html_for_nested_record():
-    data = {
-        "a": "&pound;682m",
-        "b": {
-            "c": "d",
-            "e": "&pound;682m",
-            "f": ["a", "y", "&pound;682m", "z"],
-            "g": [{"f": "k", "m": "&pound;682m"}, {"y": "l"}]
+class TestProcessRecordValues:
+    def test_should_unescape_html_for_nested_record(self):
+        data = {
+            "a": "&pound;682m",
+            "b": {
+                "c": "d",
+                "e": "&pound;682m",
+                "f": ["a", "y", "&pound;682m", "z"],
+                "g": [{"f": "k", "m": "&pound;682m"}, {"y": "l"}]
+            }
         }
-    }
-    expected_result = {
-        'a': '£682m',
-        'b': {
-            'c': 'd', 'e': '£682m',
-            'f': ['a', 'y', '£682m', 'z'],
-            'g': [{'f': 'k', 'm': '£682m'}, {'y': 'l'}]
+        expected_result = {
+            'a': '£682m',
+            'b': {
+                'c': 'd', 'e': '£682m',
+                'f': ['a', 'y', '£682m', 'z'],
+                'g': [{'f': 'k', 'm': '£682m'}, {'y': 'l'}]
+            }
         }
-    }
-    actual_result = process_record_values(data, ["html_unescape"])
-    assert actual_result == expected_result
+        actual_result = process_record_values(data, ["html_unescape"])
+        assert actual_result == expected_result


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/813

This is to parse the `payload` value of the CSV (until we have a JSON pipeline).

The `parse_json_value` processing function will parse a value as JSON, if it is a string and starts with `{` and ends with `}`.
Otherwise the passed in value is used.
(This will only be active, if `parse_json_value` is listed as a processing function)

Running this locally, it has successfully populated `s3_csv_test_sciety_event`.