### PR TITLE
Web API: disable retry for Crossref API

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -31,7 +31,7 @@ from data_pipeline.utils.json import remove_key_with_null_value
 from data_pipeline.utils.pipeline_file_io import iter_write_jsonl_to_file
 from data_pipeline.utils.pipeline_utils import iter_dict_for_bigquery_include_exclude_source_config
 from data_pipeline.utils.text import format_byte_count
-from data_pipeline.utils.web_api import requests_retry_session
+from data_pipeline.utils.web_api import requests_retry_session_for_config
 
 from data_pipeline.generic_web_api.generic_web_api_config import (
     WebApiConfig
@@ -105,7 +105,9 @@ def get_data_single_page(
         json_data
     )
 
-    with requests_retry_session() as session:
+    with requests_retry_session_for_config(
+        data_config.dynamic_request_builder.retry_config
+    ) as session:
         if (data_config.authentication and data_config.authentication.authentication_type):
             assert data_config.authentication.authentication_type == "basic"
             assert data_config.authentication.auth_val_list

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -7,6 +7,11 @@ from urllib import parse
 from typing_extensions import NotRequired, TypedDict
 
 from data_pipeline.utils.data_pipeline_timestamp import datetime_to_string
+from data_pipeline.utils.web_api import (
+    DEFAULT_WEB_API_RETRY_CONFIG,
+    DISABLED_WEB_API_RETRY_CONFIG,
+    WebApiRetryConfig
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -40,6 +45,7 @@ class WebApiDynamicRequestBuilder:
     method: str = 'GET'
     max_source_values_per_request: Optional[int] = None
     request_builder_parameters: Optional[dict] = None
+    retry_config: WebApiRetryConfig = DEFAULT_WEB_API_RETRY_CONFIG
 
     def get_json(  # pylint: disable=unused-argument
         self,
@@ -183,6 +189,13 @@ class BioRxivWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
 
 
 class CrossrefMetadataWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
+    def __init__(self, **kwargs):
+        super().__init__(**{
+            **kwargs,
+            # We need to disable retry due to Crossref API with cursor not being stateless
+            'retry_config': DISABLED_WEB_API_RETRY_CONFIG
+        })
+
     def get_url(
         self,
         dynamic_request_parameters: WebApiDynamicRequestParameters

--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -5,10 +5,15 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
+DEFAULT_MAX_RETRY_COUNT = 10
+DEFAULT_RETRY_BACKOFF_FACTOR = 0.3
+DEFAULT_RETRY_ON_RESPONSE_STATUS_LIST = (500, 502, 504)
+
+
 def requests_retry_session(
-    retries: int = 10,
-    backoff_factor: float = 0.3,
-    status_forcelist: Optional[Collection[int]] = (500, 502, 504),
+    retries: int = DEFAULT_MAX_RETRY_COUNT,
+    backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
+    status_forcelist: Optional[Collection[int]] = DEFAULT_RETRY_ON_RESPONSE_STATUS_LIST,
     session: Optional[requests.Session] = None,
     **kwargs
 ) -> requests.Session:

--- a/data_pipeline/utils/web_api.py
+++ b/data_pipeline/utils/web_api.py
@@ -1,4 +1,6 @@
-from typing import Collection, Optional
+from dataclasses import dataclass
+from typing import Collection, Optional, Sequence
+
 import requests
 from requests.adapters import HTTPAdapter
 
@@ -8,6 +10,21 @@ from urllib3.util.retry import Retry
 DEFAULT_MAX_RETRY_COUNT = 10
 DEFAULT_RETRY_BACKOFF_FACTOR = 0.3
 DEFAULT_RETRY_ON_RESPONSE_STATUS_LIST = (500, 502, 504)
+
+
+@dataclass(frozen=True)
+class WebApiRetryConfig:
+    max_retry_count: int = DEFAULT_MAX_RETRY_COUNT
+    retry_backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR
+    retry_on_response_status_list: Sequence[int] = DEFAULT_RETRY_ON_RESPONSE_STATUS_LIST
+
+
+DEFAULT_WEB_API_RETRY_CONFIG = WebApiRetryConfig()
+
+DISABLED_WEB_API_RETRY_CONFIG = WebApiRetryConfig(
+    max_retry_count=0,
+    retry_on_response_status_list=tuple([])
+)
 
 
 def requests_retry_session(
@@ -30,3 +47,17 @@ def requests_retry_session(
     session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session
+
+
+def requests_retry_session_for_config(
+    config: WebApiRetryConfig,
+    session: Optional[requests.Session] = None,
+    **kwargs
+) -> requests.Session:
+    return requests_retry_session(
+        retries=config.max_retry_count,
+        backoff_factor=config.retry_backoff_factor,
+        status_forcelist=config.retry_on_response_status_list,
+        session=session,
+        **kwargs
+    )

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -53,7 +53,10 @@ def _requests_session_mock() -> MagicMock:
 
 @pytest.fixture(name='requests_retry_session_mock', autouse=True)
 def _requests_retry_session_mock(requests_session_mock: MagicMock) -> Iterator[MagicMock]:
-    with patch.object(generic_web_api_data_etl_module, 'requests_retry_session') as mock:
+    with patch.object(
+        generic_web_api_data_etl_module,
+        'requests_retry_session_for_config'
+    ) as mock:
         mock.return_value.__enter__.return_value = requests_session_mock
         yield mock
 

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -9,6 +9,7 @@ from data_pipeline.generic_web_api.request_builder import (
     BioRxivWebApiDynamicRequestBuilder,
     WebApiDynamicRequestParameters
 )
+from data_pipeline.utils.web_api import DISABLED_WEB_API_RETRY_CONFIG
 
 
 LOGGER = logging.getLogger(__name__)
@@ -46,6 +47,14 @@ class TestDynamicBioRxivMedRxivURLBuilder:
 
 
 class TestCrossrefMetadataWebApiDynamicRequestBuilder:
+    def test_should_disable_retry(self):
+        dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1,
+            next_page_cursor='cursor',
+            static_parameters={}
+        )
+        assert dynamic_request_builder.retry_config == DISABLED_WEB_API_RETRY_CONFIG
+
     def test_should_pass_cursor_value_to_url(self):
         dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
             url_excluding_configurable_parameters=TEST_API_URL_1,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

Disable retry for Crossref API because it isn't stateless when using a cursor.

This is currently hardcoded in the request builder rather than being configurable via the config file.