### PR TITLE
Web API: use total to report on progress and missing records

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -315,6 +315,9 @@ def iter_processed_web_api_data_etl_batch_data(
             dynamic_request_parameters=current_dynamic_request_parameters
         )
         LOGGER.debug('page_data: %r', page_data)
+        total_count = get_optional_total_count(page_data, data_config)
+        if total_count:
+            LOGGER.info('Total items (reported by API): %d', total_count)
         items_list = get_items_list(
             page_data, data_config
         )
@@ -596,6 +599,15 @@ def get_next_cursor_from_data(
             LOGGER.info('Ignoring cursor that is the same as previous cursor: %r', next_cursor)
             return None
         return next_cursor
+    return None
+
+
+def get_optional_total_count(page_data, web_config: WebApiConfig) -> Optional[int]:
+    if web_config.response.total_item_count_key_path_from_response_root:
+        return get_dict_values_from_path_as_list(
+            page_data,
+            web_config.response.total_item_count_key_path_from_response_root
+        )
     return None
 
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -360,6 +360,9 @@ def iter_processed_web_api_data_etl_batch_data(
             all_source_values_iterator=all_source_values_iterator
         )
 
+    if progress_monitor.is_incomplete():
+        LOGGER.warning('Not all of the expected records received from API')
+
 
 def iter_optional_batch_iterable(
     iterable: Iterable[T],

--- a/data_pipeline/utils/progress.py
+++ b/data_pipeline/utils/progress.py
@@ -18,7 +18,7 @@ class ProgressMonitor:
         self.total = total
 
     def is_incomplete(self) -> bool:
-        return self.total and self.current < self.total
+        return bool(self.total and self.current < self.total)
 
     def get_progress_message(self) -> str:
         if self.total:

--- a/data_pipeline/utils/progress.py
+++ b/data_pipeline/utils/progress.py
@@ -19,7 +19,8 @@ class ProgressMonitor:
 
     def get_progress_message(self) -> str:
         if self.total:
-            return f'{self.message_prefix}{self.current} of {self.total}'
+            percent = 100 * self.current / self.total
+            return f'{self.message_prefix}{self.current} of {self.total} ({percent:.1f}%)'
         return f'{self.message_prefix}{self.current} (unknown total)'
 
     def __repr__(self):

--- a/data_pipeline/utils/progress.py
+++ b/data_pipeline/utils/progress.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+
+class ProgressMonitor:
+    def __init__(
+        self,
+        total: Optional[int] = None,
+        message_prefix: str = 'progress: '
+    ):
+        self.total = total
+        self.current = 0
+        self.message_prefix = message_prefix
+
+    def increment(self, n: int = 1):
+        self.current += n
+
+    def set_total(self, total: Optional[int]):
+        self.total = total
+
+    def get_progress_message(self) -> str:
+        if self.total:
+            return f'{self.message_prefix}{self.current} of {self.total}'
+        return f'{self.message_prefix}{self.current} (unknown total)'
+
+    def __repr__(self):
+        return f'{type(self).__name__}(current={self.current}, total={self.total})'
+
+    def __str__(self):
+        return self.get_progress_message()

--- a/data_pipeline/utils/progress.py
+++ b/data_pipeline/utils/progress.py
@@ -23,7 +23,7 @@ class ProgressMonitor:
     def get_progress_message(self) -> str:
         if self.total:
             percent = 100 * self.current / self.total
-            return f'{self.message_prefix}{self.current} of {self.total} ({percent:.1f}%)'
+            return f'{self.message_prefix}{self.current:,} of {self.total:,} ({percent:.1f}%)'
         return f'{self.message_prefix}{self.current} (unknown total)'
 
     def __repr__(self):

--- a/data_pipeline/utils/progress.py
+++ b/data_pipeline/utils/progress.py
@@ -11,11 +11,14 @@ class ProgressMonitor:
         self.current = 0
         self.message_prefix = message_prefix
 
-    def increment(self, n: int = 1):
-        self.current += n
+    def increment(self, delta: int = 1):
+        self.current += delta
 
     def set_total(self, total: Optional[int]):
         self.total = total
+
+    def is_incomplete(self) -> bool:
+        return self.total and self.current < self.total
 
     def get_progress_message(self) -> str:
         if self.total:

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -99,6 +99,9 @@ webApi:
       itemsKeyFromResponseRoot:
         - message
         - items
+      totalItemsCountKeyFromResponseRoot:
+        - message
+        - total-results
       recordTimestamp:
         itemTimestampKeyFromItemRoot:
           - 'indexed'

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -14,6 +14,7 @@ from data_pipeline.generic_web_api.generic_web_api_data_etl import (
     get_data_single_page,
     get_initial_dynamic_request_parameters,
     get_next_dynamic_request_parameters_for_page_data,
+    get_optional_total_count,
     upload_latest_timestamp_as_pipeline_state,
     get_items_list,
     get_next_cursor_from_data,
@@ -222,6 +223,24 @@ class TestUploadLatestTimestampState:
             object_key=state_file_name_key,
             data_object=latest_timestamp_string,
         )
+
+
+class TestGetOptionalTotalCount:
+    def test_should_return_none_if_no_total_path_configured(self):
+        data_config = get_data_config(WEB_API_CONFIG)
+        data = {'total': 123}
+        assert get_optional_total_count(data, data_config) is None
+
+    def test_should_return_total_from_response(self):
+        conf_dict = {
+            **WEB_API_CONFIG,
+            'response': {
+                'totalItemsCountKeyFromResponseRoot': ['total']
+            }
+        }
+        data_config = get_data_config(conf_dict)
+        data = {'total': 123}
+        assert get_optional_total_count(data, data_config) == 123
 
 
 class TestGetItemList:

--- a/tests/unit_test/utils/progress_test.py
+++ b/tests/unit_test/utils/progress_test.py
@@ -11,4 +11,4 @@ class TestProgressMonitor:
         progress_monitor = ProgressMonitor(message_prefix='test:')
         progress_monitor.set_total(100)
         progress_monitor.increment(10)
-        assert str(progress_monitor) == 'test:10 of 100'
+        assert str(progress_monitor) == 'test:10 of 100 (10.0%)'

--- a/tests/unit_test/utils/progress_test.py
+++ b/tests/unit_test/utils/progress_test.py
@@ -1,0 +1,14 @@
+from data_pipeline.utils.progress import ProgressMonitor
+
+
+class TestProgressMonitor:
+    def test_should_return_progress_message_without_total(self):
+        progress_monitor = ProgressMonitor(message_prefix='test:')
+        progress_monitor.increment(10)
+        assert str(progress_monitor) == 'test:10 (unknown total)'
+
+    def test_should_return_progress_message_with_total(self):
+        progress_monitor = ProgressMonitor(message_prefix='test:')
+        progress_monitor.set_total(100)
+        progress_monitor.increment(10)
+        assert str(progress_monitor) == 'test:10 of 100'

--- a/tests/unit_test/utils/progress_test.py
+++ b/tests/unit_test/utils/progress_test.py
@@ -13,6 +13,12 @@ class TestProgressMonitor:
         progress_monitor.increment(10)
         assert str(progress_monitor) == 'test:10 of 100 (10.0%)'
 
+    def test_should_use_thousands_separator_for_large_numbers(self):
+        progress_monitor = ProgressMonitor(message_prefix='test:')
+        progress_monitor.set_total(123456789)
+        progress_monitor.increment(123456789)
+        assert str(progress_monitor) == 'test:123,456,789 of 123,456,789 (100.0%)'
+
     def test_should_report_incomplete_if_total_is_known_and_current_is_less(self):
         progress_monitor = ProgressMonitor(total=100)
         progress_monitor.increment(10)

--- a/tests/unit_test/utils/progress_test.py
+++ b/tests/unit_test/utils/progress_test.py
@@ -12,3 +12,18 @@ class TestProgressMonitor:
         progress_monitor.set_total(100)
         progress_monitor.increment(10)
         assert str(progress_monitor) == 'test:10 of 100 (10.0%)'
+
+    def test_should_report_incomplete_if_total_is_known_and_current_is_less(self):
+        progress_monitor = ProgressMonitor(total=100)
+        progress_monitor.increment(10)
+        assert progress_monitor.is_incomplete()
+
+    def test_should_report_incomplete_false_if_current_equals_total(self):
+        progress_monitor = ProgressMonitor(total=100)
+        progress_monitor.increment(100)
+        assert not progress_monitor.is_incomplete()
+
+    def test_should_report_incomplete_false_if_total_is_unknown(self):
+        progress_monitor = ProgressMonitor()
+        progress_monitor.increment(100)
+        assert not progress_monitor.is_incomplete()


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

Example logging:

> [2024-02-01, 13:43:17 UTC] {generic_web_api_data_etl.py:322} INFO - Total items (reported by API): 80516
>  ...
> [2024-02-01, 13:43:31 UTC] {generic_web_api_data_etl.py:322} INFO - Total items (reported by API): 80516
> ...
> [2024-02-01, 13:43:44 UTC] {generic_web_api_data_etl.py:349} INFO - Processed records (before BigQuery): 2000 of 80516 (2.5%)
> ...
> [2024-02-01, 13:43:44 UTC] {generic_web_api_data_etl.py:364} WARNING - Not all of the expected records received from API

For the progress I previously used `tqdm` but it is not so convenient in combination with logging. A previous PR to help with that hasn't been merged. And that would be more lines than the simple progress monitor in here.