### PR TITLE
Crossref Web API: Allow same page cursor

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -325,6 +325,9 @@ def iter_processed_web_api_data_etl_batch_data(
             page_data, data_config
         )
         LOGGER.debug('items_list: %r', items_list)
+        if not items_list:
+            LOGGER.info('Item list is empty, end reached')
+            break
         items_list = remove_key_with_null_value(items_list)
         progress_monitor.increment(len(items_list))
         LOGGER.debug('items_list after removed null values: %r', items_list)

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -605,8 +605,13 @@ def get_next_cursor_from_data(
             web_config.response.next_page_cursor_key_path_from_response_root
         )
         if next_cursor and next_cursor == previous_cursor:
-            LOGGER.info('Ignoring cursor that is the same as previous cursor: %r', next_cursor)
-            return None
+            if not web_config.dynamic_request_builder.allow_same_next_page_cursor:
+                LOGGER.info('Ignoring cursor that is the same as previous cursor: %r', next_cursor)
+                return None
+            LOGGER.info(
+                'Proceeding with cursor that is the same as previous cursor: %r',
+                next_cursor
+            )
         return next_cursor
     return None
 

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -36,6 +36,7 @@ class WebApiDynamicRequestBuilder:
     to_date_param: Optional[str] = None
     date_format: Optional[str] = None
     next_page_cursor: Optional[str] = None
+    allow_same_next_page_cursor: bool = False
     page_number_param: Optional[str] = None
     offset_param: Optional[str] = None
     page_size_param: Optional[str] = None
@@ -193,7 +194,9 @@ class CrossrefMetadataWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
         super().__init__(**{
             **kwargs,
             # We need to disable retry due to Crossref API with cursor not being stateless
-            'retry_config': DISABLED_WEB_API_RETRY_CONFIG
+            'retry_config': DISABLED_WEB_API_RETRY_CONFIG,
+            # We are allowing the next page cursor to be the same as the previous cursor
+            'allow_same_next_page_cursor': True
         })
 
     def get_url(

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -380,13 +380,28 @@ class TestNextCursor:
         )
         assert actual_next_cursor == 'cursor1'
 
-    def test_should_ignore_get_cursor_value_when_matching_previous_cursor(self):
+    def test_should_ignore_get_cursor_value_when_matching_previous_cursor_by_default(self):
         data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
         data = {'cursor_key1': 'cursor1'}
         actual_next_cursor = get_next_cursor_from_data(
             data, data_config, previous_cursor='cursor1'
         )
         assert actual_next_cursor is None
+
+    def test_should_not_ignore_same_cursor_if_configured_to_allow_it(self):
+        data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])
+        data_config = dataclasses.replace(
+            data_config,
+            dynamic_request_builder=dataclasses.replace(
+                data_config.dynamic_request_builder,
+                allow_same_next_page_cursor=True
+            )
+        )
+        data = {'cursor_key1': 'cursor1'}
+        actual_next_cursor = get_next_cursor_from_data(
+            data, data_config, previous_cursor='cursor1'
+        )
+        assert actual_next_cursor == 'cursor1'
 
     def test_should_be_none_when_configured_but_not_in_data(self):
         data_config = _get_web_api_config_with_cursor_path(cursor_path=['cursor_key1'])

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -5,17 +5,32 @@ from urllib.parse import parse_qs, urlparse
 from data_pipeline.generic_web_api.request_builder import (
     CrossrefMetadataWebApiDynamicRequestBuilder,
     S2TitleAbstractEmbeddingsWebApiDynamicRequestBuilder,
+    WebApiDynamicRequestBuilder,
     get_web_api_request_builder_class,
     BioRxivWebApiDynamicRequestBuilder,
     WebApiDynamicRequestParameters
 )
-from data_pipeline.utils.web_api import DISABLED_WEB_API_RETRY_CONFIG
+from data_pipeline.utils.web_api import (
+    DEFAULT_WEB_API_RETRY_CONFIG,
+    DISABLED_WEB_API_RETRY_CONFIG
+)
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 TEST_API_URL_1 = 'https://test/api1'
+
+
+class TestWebApiDynamicRequestBuilder:
+    def test_should_enable_retry_and_not_allow_next_page_cursor(self):
+        dynamic_request_builder = WebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1,
+            next_page_cursor='cursor',
+            static_parameters={}
+        )
+        assert dynamic_request_builder.retry_config == DEFAULT_WEB_API_RETRY_CONFIG
+        assert not dynamic_request_builder.allow_same_next_page_cursor
 
 
 class TestDynamicBioRxivMedRxivURLBuilder:
@@ -47,13 +62,14 @@ class TestDynamicBioRxivMedRxivURLBuilder:
 
 
 class TestCrossrefMetadataWebApiDynamicRequestBuilder:
-    def test_should_disable_retry(self):
+    def test_should_disable_retry_and_allow_next_page_cursor(self):
         dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
             url_excluding_configurable_parameters=TEST_API_URL_1,
             next_page_cursor='cursor',
             static_parameters={}
         )
         assert dynamic_request_builder.retry_config == DISABLED_WEB_API_RETRY_CONFIG
+        assert dynamic_request_builder.allow_same_next_page_cursor
 
     def test_should_pass_cursor_value_to_url(self):
         dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

Previously when the next cursor is the same, it was ignored and signified the end.
This was to avoid infinite loops.

But for the Crossref API that is normal behaviour.
This PR allow the same page cursor for pagination in combination with the Crossref API.
It also stops when the item list is empty. This avoids having to rely on comparison the number of received records with the expected total reported by the API.