### PR TITLE
Web API: Add extended provenance

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -96,6 +96,7 @@ class WebApiResponseConfig:
     item_timestamp_key_path_from_item_root: Sequence[str] = field(default_factory=list)
     fields_to_return: Optional[Sequence[str]] = None
     record_processing_step_function: Optional[RecordProcessingStepFunction] = None
+    detailed_provenance_enabled: bool = False
 
     @staticmethod
     def from_dict(
@@ -122,6 +123,9 @@ class WebApiResponseConfig:
                 get_single_record_processing_step_function_for_function_names_or_none(
                     web_api_response_config.get('recordProcessingSteps')
                 )
+            ),
+            detailed_provenance_enabled=web_api_response_config.get(
+                'detailedProvenance', False
             )
         )
 

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -125,7 +125,7 @@ class WebApiResponseConfig:
                 )
             ),
             detailed_provenance_enabled=web_api_response_config.get(
-                'detailedProvenance', False
+                'provenanceEnabled', False
             )
         )
 

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -96,7 +96,7 @@ class WebApiResponseConfig:
     item_timestamp_key_path_from_item_root: Sequence[str] = field(default_factory=list)
     fields_to_return: Optional[Sequence[str]] = None
     record_processing_step_function: Optional[RecordProcessingStepFunction] = None
-    detailed_provenance_enabled: bool = False
+    provenance_enabled: bool = False
 
     @staticmethod
     def from_dict(
@@ -124,7 +124,7 @@ class WebApiResponseConfig:
                     web_api_response_config.get('recordProcessingSteps')
                 )
             ),
-            detailed_provenance_enabled=web_api_response_config.get(
+            provenance_enabled=web_api_response_config.get(
                 'provenanceEnabled', False
             )
         )

--- a/data_pipeline/generic_web_api/generic_web_api_config_typing.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config_typing.py
@@ -70,7 +70,7 @@ class WebApiResponseConfigDict(TypedDict):
     recordTimestamp: NotRequired[WebApiRecordTimestampResponseConfigDict]
     fieldsToReturn: NotRequired[Sequence[str]]
     recordProcessingSteps: NotRequired[RecordProcessingStepConfigList]
-    detailedProvenance: NotRequired[bool]
+    provenanceEnabled: NotRequired[bool]
 
 
 class WebApiBaseConfigDict(TypedDict):

--- a/data_pipeline/generic_web_api/generic_web_api_config_typing.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config_typing.py
@@ -70,6 +70,7 @@ class WebApiResponseConfigDict(TypedDict):
     recordTimestamp: NotRequired[WebApiRecordTimestampResponseConfigDict]
     fieldsToReturn: NotRequired[Sequence[str]]
     recordProcessingSteps: NotRequired[RecordProcessingStepConfigList]
+    detailedProvenance: NotRequired[bool]
 
 
 class WebApiBaseConfigDict(TypedDict):

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -96,7 +96,7 @@ def get_newline_delimited_json_string_as_json_list(json_string):
 @dataclasses.dataclass(frozen=True)
 class WebApiPageResponse:
     response_json: Any
-    request_provenance: dict
+    request_provenance: dict = dataclasses.field(default_factory=dict)
 
 
 def get_data_single_page_response(

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -332,11 +332,12 @@ def iter_processed_web_api_data_etl_batch_data(
     progress_monitor = ProgressMonitor(message_prefix='Processed records (before BigQuery): ')
     while current_dynamic_request_parameters:
         LOGGER.debug('current_dynamic_request_parameters=%r', current_dynamic_request_parameters)
-        page_data = get_data_single_page(
+        page_response = get_data_single_page_response(
             data_config=data_config,
             dynamic_request_parameters=current_dynamic_request_parameters
         )
-        LOGGER.debug('page_data: %r', page_data)
+        LOGGER.debug('page_response: %r', page_response)
+        page_data = page_response.response_json
         total_count = get_optional_total_count(page_data, data_config)
         if total_count:
             LOGGER.info('Total items (reported by API): %d', total_count)

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -154,11 +154,6 @@ def get_data_single_page_response(
     )
 
 
-def get_data_single_page(*args, **kwargs) -> Any:
-    page_response = get_data_single_page_response(*args, **kwargs)
-    return page_response.response_json
-
-
 def iter_optional_source_values_from_bigquery(
     data_config: WebApiConfig
 ) -> Optional[Iterable[dict]]:

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -1,3 +1,4 @@
+import dataclasses
 import itertools
 import os
 import logging
@@ -92,10 +93,16 @@ def get_newline_delimited_json_string_as_json_list(json_string):
     ]
 
 
-def get_data_single_page(
+@dataclasses.dataclass(frozen=True)
+class WebApiPageResponse:
+    response_json: Any
+    request_provenance: dict
+
+
+def get_data_single_page_response(
     data_config: WebApiConfig,
     dynamic_request_parameters: WebApiDynamicRequestParameters
-) -> Any:
+) -> WebApiPageResponse:
     url = data_config.dynamic_request_builder.get_url(
         dynamic_request_parameters
     )
@@ -141,7 +148,15 @@ def get_data_single_page(
             format_byte_count(len(resp)),
             format_byte_count(parsed_response_size)
         )
-    return json_resp
+    return WebApiPageResponse(
+        response_json=json_resp,
+        request_provenance=request_provenance
+    )
+
+
+def get_data_single_page(*args, **kwargs) -> Any:
+    page_response = get_data_single_page_response(*args, **kwargs)
+    return page_response.response_json
 
 
 def iter_optional_source_values_from_bigquery(

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -29,7 +29,10 @@ from data_pipeline.utils.data_store.bq_data_service import (
 )
 from data_pipeline.utils.json import remove_key_with_null_value
 from data_pipeline.utils.pipeline_file_io import iter_write_jsonl_to_file
-from data_pipeline.utils.pipeline_utils import iter_dict_for_bigquery_include_exclude_source_config
+from data_pipeline.utils.pipeline_utils import (
+    get_response_and_provenance_from_api,
+    iter_dict_for_bigquery_include_exclude_source_config
+)
 from data_pipeline.utils.progress import ProgressMonitor
 from data_pipeline.utils.text import format_byte_count
 from data_pipeline.utils.web_api import requests_retry_session_for_config
@@ -115,13 +118,15 @@ def get_data_single_page(
             session.auth = cast(Tuple[str, str], tuple(data_config.authentication.auth_val_list))
         session.verify = False
         LOGGER.info("Headers: %s", data_config.headers)
-        session_response = session.request(
+        session_response, request_provenance = get_response_and_provenance_from_api(
+            session=session,
             method=data_config.dynamic_request_builder.method,
             url=url,
-            json=json_data,
-            headers=data_config.headers.mapping
+            json_data=json_data,
+            headers=data_config.headers.mapping,
+            raise_on_status=True
         )
-        session_response.raise_for_status()
+        LOGGER.info('Request Provenance: %r', request_provenance)
         resp = session_response.content
         try:
             json_resp = json.loads(resp)

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -357,7 +357,8 @@ def iter_processed_web_api_data_etl_batch_data(
             data_config=data_config,
             provenance=get_web_api_provenance(
                 data_config=data_config,
-                data_etl_timestamp=imported_timestamp
+                data_etl_timestamp=imported_timestamp,
+                request_provenance=page_response.request_provenance
             )
         )
 

--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -259,7 +259,7 @@ def get_web_api_provenance(
     result: dict = {
         data_config.import_timestamp_field_name: data_etl_timestamp
     }
-    if data_config.response.detailed_provenance_enabled and request_provenance:
+    if data_config.response.provenance_enabled and request_provenance:
         result[DETAILED_PROVENANCE_FIELD_NAME] = request_provenance
     return result
 

--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -27,7 +27,7 @@ from data_pipeline.utils.record_processing import RecordProcessingStepFunction
 LOGGER = logging.getLogger(__name__)
 
 
-DETAILED_PROVENANCE_FIELD_NAME = 'provenance'
+PROVENANCE_FIELD_NAME = 'provenance'
 
 
 def get_dict_values_from_path_as_list(
@@ -260,7 +260,7 @@ def get_web_api_provenance(
         data_config.import_timestamp_field_name: data_etl_timestamp
     }
     if data_config.response.provenance_enabled and request_provenance:
-        result[DETAILED_PROVENANCE_FIELD_NAME] = request_provenance
+        result[PROVENANCE_FIELD_NAME] = request_provenance
     return result
 
 

--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -27,6 +27,9 @@ from data_pipeline.utils.record_processing import RecordProcessingStepFunction
 LOGGER = logging.getLogger(__name__)
 
 
+DETAILED_PROVENANCE_FIELD_NAME = 'provenance'
+
+
 def get_dict_values_from_path_as_list(
         page_data, path_keys: Sequence[str]
 ):
@@ -250,11 +253,15 @@ def iter_processed_record_for_api_item_list_response(
 
 def get_web_api_provenance(
     data_config: WebApiConfig,
-    data_etl_timestamp: str
+    data_etl_timestamp: str,
+    request_provenance: Optional[dict] = None
 ) -> dict:
-    return {
+    result: dict = {
         data_config.import_timestamp_field_name: data_etl_timestamp
     }
+    if data_config.response.detailed_provenance_enabled and request_provenance:
+        result[DETAILED_PROVENANCE_FIELD_NAME] = request_provenance
+    return result
 
 
 def get_bq_schema(data_config: WebApiConfig,):

--- a/data_pipeline/generic_web_api/transform_data.py
+++ b/data_pipeline/generic_web_api/transform_data.py
@@ -250,7 +250,7 @@ def iter_processed_record_for_api_item_list_response(
 
 def get_web_api_provenance(
     data_config: WebApiConfig,
-    data_etl_timestamp: datetime
+    data_etl_timestamp: str
 ) -> dict:
     return {
         data_config.import_timestamp_field_name: data_etl_timestamp

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from json.decoder import JSONDecodeError
-from typing import Any, Iterable, Mapping, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
 
 import requests
 
@@ -138,7 +138,7 @@ def get_default_printable_mapping_with_secrets(
     return None
 
 
-def get_response_json_with_provenance_from_api(  # noqa pylint: disable=too-many-arguments,too-many-locals
+def get_response_and_provenance_from_api(  # noqa pylint: disable=too-many-arguments,too-many-locals
     url: str,
     params: Optional[Mapping[str, str]] = None,
     headers: Optional[Mapping[str, str]] = None,
@@ -149,7 +149,7 @@ def get_response_json_with_provenance_from_api(  # noqa pylint: disable=too-many
     session: Optional[requests.Session] = None,
     raise_on_status: bool = True,
     progress_message: Optional[str] = None
-) -> dict:
+) -> Tuple[requests.Response, dict]:
     progress_message_str = (
         f'({progress_message})'
         if progress_message
@@ -201,6 +201,11 @@ def get_response_json_with_provenance_from_api(  # noqa pylint: disable=too-many
         ]
     if json_data:
         request_provenance['json_data'] = json_data
+    return response, request_provenance
+
+
+def get_response_json_with_provenance_from_api(*args, **kwargs) -> dict:
+    response, request_provenance = get_response_and_provenance_from_api(*args, **kwargs)
     return {
         **get_valid_json_from_response(response),
         'provenance': request_provenance

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -113,4 +113,4 @@ webApi:
       #   - 'indexed'
       recordProcessingSteps:
         - transform_crossref_api_date_parts
-      detailedProvenance: True
+      provenanceEnabled: True

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -113,3 +113,4 @@ webApi:
       #   - 'indexed'
       recordProcessingSteps:
         - transform_crossref_api_date_parts
+      detailedProvenance: True

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -127,12 +127,12 @@ class TestWebApiResponseConfig:
             get_single_record_processing_step_function_for_function_names_or_none_mock.return_value
         )
 
-    def test_should_not_enable_detailed_provenance_by_default(self):
+    def test_should_not_enable_provenance_by_default(self):
         response_config = WebApiResponseConfig.from_dict({
         })
         assert not response_config.provenance_enabled
 
-    def test_should_read_detailed_provenance_config(self):
+    def test_should_read_provenance_enabled_config(self):
         response_config = WebApiResponseConfig.from_dict({
             'provenanceEnabled': True
         })

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -127,6 +127,17 @@ class TestWebApiResponseConfig:
             get_single_record_processing_step_function_for_function_names_or_none_mock.return_value
         )
 
+    def test_should_not_enable_detailed_provenance_by_default(self):
+        response_config = WebApiResponseConfig.from_dict({
+        })
+        assert not response_config.detailed_provenance_enabled
+
+    def test_should_read_detailed_provenance_config(self):
+        response_config = WebApiResponseConfig.from_dict({
+            'detailedProvenance': True
+        })
+        assert response_config.detailed_provenance_enabled
+
 
 class TestWebApiConfig:
     def test_should_parse_dataset_and_table(self):

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -130,13 +130,13 @@ class TestWebApiResponseConfig:
     def test_should_not_enable_detailed_provenance_by_default(self):
         response_config = WebApiResponseConfig.from_dict({
         })
-        assert not response_config.detailed_provenance_enabled
+        assert not response_config.provenance_enabled
 
     def test_should_read_detailed_provenance_config(self):
         response_config = WebApiResponseConfig.from_dict({
             'provenanceEnabled': True
         })
-        assert response_config.detailed_provenance_enabled
+        assert response_config.provenance_enabled
 
 
 class TestWebApiConfig:

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -134,7 +134,7 @@ class TestWebApiResponseConfig:
 
     def test_should_read_detailed_provenance_config(self):
         response_config = WebApiResponseConfig.from_dict({
-            'detailedProvenance': True
+            'provenanceEnabled': True
         })
         assert response_config.detailed_provenance_enabled
 

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -265,7 +265,7 @@ class TestGetWebApiProvenance:
             data_config.import_timestamp_field_name: TIMESTAMP_STR_1
         }
 
-    def test_should_not_include_detailed_provenance_if_disabled(self):
+    def test_should_not_include_provenance_if_disabled(self):
         data_config = dataclasses.replace(
             get_data_config(MINIMAL_WEB_API_CONFIG_DICT),
             response=WebApiResponseConfig(

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -3,7 +3,7 @@ import pytest
 from data_pipeline.generic_web_api.generic_web_api_config import WebApiResponseConfig
 
 from data_pipeline.generic_web_api.transform_data import (
-    DETAILED_PROVENANCE_FIELD_NAME,
+    PROVENANCE_FIELD_NAME,
     filter_record_by_schema,
     get_dict_values_from_path_as_list,
     get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root,
@@ -277,7 +277,7 @@ class TestGetWebApiProvenance:
             data_etl_timestamp=TIMESTAMP_STR_1,
             request_provenance=REQUEST_PROVENANCE_1
         )
-        assert DETAILED_PROVENANCE_FIELD_NAME not in provenance_dict
+        assert PROVENANCE_FIELD_NAME not in provenance_dict
 
     def test_should_include_request_provenance_if_enabled(self):
         data_config = dataclasses.replace(
@@ -291,4 +291,4 @@ class TestGetWebApiProvenance:
             data_etl_timestamp=TIMESTAMP_STR_1,
             request_provenance=REQUEST_PROVENANCE_1
         )
-        assert provenance_dict.get(DETAILED_PROVENANCE_FIELD_NAME) == REQUEST_PROVENANCE_1
+        assert provenance_dict.get(PROVENANCE_FIELD_NAME) == REQUEST_PROVENANCE_1

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -250,10 +250,10 @@ class TestIterProcessedRecordForApiItemListResponse:
 class TestGetWebApiProvenance:
     def test_should_include_imported_timestamp_with_configured_key(self):
         data_config = get_data_config(MINIMAL_WEB_API_CONFIG_DICT)
-        proveance_dict = get_web_api_provenance(
+        provenance_dict = get_web_api_provenance(
             data_config=data_config,
             data_etl_timestamp=TIMESTAMP_STR_1
         )
-        assert proveance_dict == {
+        assert provenance_dict == {
             data_config.import_timestamp_field_name: TIMESTAMP_STR_1
         }

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -269,7 +269,7 @@ class TestGetWebApiProvenance:
         data_config = dataclasses.replace(
             get_data_config(MINIMAL_WEB_API_CONFIG_DICT),
             response=WebApiResponseConfig(
-                detailed_provenance_enabled=False
+                provenance_enabled=False
             )
         )
         provenance_dict = get_web_api_provenance(
@@ -283,7 +283,7 @@ class TestGetWebApiProvenance:
         data_config = dataclasses.replace(
             get_data_config(MINIMAL_WEB_API_CONFIG_DICT),
             response=WebApiResponseConfig(
-                detailed_provenance_enabled=True
+                provenance_enabled=True
             )
         )
         provenance_dict = get_web_api_provenance(

--- a/tests/unit_test/generic_web_api/transform_data_test.py
+++ b/tests/unit_test/generic_web_api/transform_data_test.py
@@ -5,6 +5,7 @@ from data_pipeline.generic_web_api.transform_data import (
     filter_record_by_schema,
     get_dict_values_from_path_as_list,
     get_latest_record_list_timestamp_for_item_timestamp_key_path_from_item_root,
+    get_web_api_provenance,
     iter_processed_record_for_api_item_list_response,
     process_record_in_list
 )
@@ -244,3 +245,15 @@ class TestIterProcessedRecordForApiItemListResponse:
         assert updated_records == [{
             'key_1': 'new value 1'
         }]
+
+
+class TestGetWebApiProvenance:
+    def test_should_include_imported_timestamp_with_configured_key(self):
+        data_config = get_data_config(MINIMAL_WEB_API_CONFIG_DICT)
+        proveance_dict = get_web_api_provenance(
+            data_config=data_config,
+            data_etl_timestamp=TIMESTAMP_STR_1
+        )
+        assert proveance_dict == {
+            data_config.import_timestamp_field_name: TIMESTAMP_STR_1
+        }


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

We are planning to ingest multiple DOI prefixes.
Because the Crossref response is sometimes a bit unpredictable, having the more detailed response will make it easier to point to where the records came from.

It is re-using the detailed provenance we used for some other pipelines too.