### PR TITLE
Web API: Ingest from multiple Crossref prefixes

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -32,7 +32,8 @@ from data_pipeline.utils.json import remove_key_with_null_value
 from data_pipeline.utils.pipeline_file_io import iter_write_jsonl_to_file
 from data_pipeline.utils.pipeline_utils import (
     get_response_and_provenance_from_api,
-    iter_dict_for_bigquery_include_exclude_source_config
+    iter_dict_for_bigquery_include_exclude_source_config,
+    replace_placeholders
 )
 from data_pipeline.utils.progress import ProgressMonitor
 from data_pipeline.utils.text import format_byte_count
@@ -707,7 +708,8 @@ def get_items_list(page_data, web_config: WebApiConfig):
 
 def upload_latest_timestamp_as_pipeline_state(
     data_config: WebApiConfig,
-    latest_record_timestamp: datetime
+    latest_record_timestamp: datetime,
+    placeholder_values: Optional[dict] = None
 ):
     if (
         data_config.state_file_object_name and
@@ -717,7 +719,10 @@ def upload_latest_timestamp_as_pipeline_state(
             get_tz_aware_datetime(latest_record_timestamp),
             ModuleConstant.DEFAULT_TIMESTAMP_FORMAT
         )
-        state_file_name_key = data_config.state_file_object_name
+        state_file_name_key = replace_placeholders(
+            data_config.state_file_object_name,
+            placeholder_values
+        )
         state_file_bucket = data_config.state_file_bucket_name
         upload_s3_object(
             bucket=state_file_bucket,

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -267,7 +267,8 @@ def get_initial_dynamic_request_parameters(
     data_config: WebApiConfig,
     initial_from_date: Optional[datetime] = None,
     fixed_until_date: Optional[datetime] = None,
-    all_source_values_iterator: Optional[Iterable[dict]] = None
+    all_source_values_iterator: Optional[Iterable[dict]] = None,
+    placeholder_values: Optional[dict] = None
 ) -> Optional[WebApiDynamicRequestParameters]:
     initial_source_values = get_next_source_values_or_none(
         data_config=data_config,
@@ -286,7 +287,8 @@ def get_initial_dynamic_request_parameters(
         cursor=None,
         page_number=1 if data_config.dynamic_request_builder.page_number_param else None,
         page_offset=0 if data_config.dynamic_request_builder.offset_param else None,
-        source_values=initial_source_values
+        source_values=initial_source_values,
+        placeholder_values=placeholder_values
     )
 
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -460,6 +460,7 @@ def process_web_api_data_etl_batch(
     all_source_values_iterator: Optional[Iterable[dict]] = None
 ):
     if should_iterate_over_source_values(data_config, all_source_values_iterator):
+        assert all_source_values_iterator is not None
         for batch_source_value in all_source_values_iterator:
             process_web_api_data_etl_batch_with_batch_source_value(
                 data_config=data_config,

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -395,12 +395,14 @@ def iter_optional_batch_iterable(
     return iter_batch_iterable(iterable, batch_size)
 
 
-def process_web_api_data_etl_batch(
+def process_web_api_data_etl_batch_with_batch_source_value(
     data_config: WebApiConfig,
     initial_from_date: Optional[datetime] = None,
     until_date: Optional[datetime] = None,
-    all_source_values_iterator: Optional[Iterable[dict]] = None
+    all_source_values_iterator: Optional[Iterable[dict]] = None,
+    batch_source_value: Optional[dict] = None
 ):
+    LOGGER.debug('batch_source_value: %r', batch_source_value)
     all_processed_record_iterable = iter_processed_web_api_data_etl_batch_data(
         data_config=data_config,
         initial_from_date=initial_from_date,
@@ -439,6 +441,21 @@ def process_web_api_data_etl_batch(
             else:
                 LOGGER.info('not updating state due to no latest record timestamp')
         LOGGER.info('completed batch: %d', 1 + batch_index)
+
+
+def process_web_api_data_etl_batch(
+    data_config: WebApiConfig,
+    initial_from_date: Optional[datetime] = None,
+    until_date: Optional[datetime] = None,
+    all_source_values_iterator: Optional[Iterable[dict]] = None
+):
+    process_web_api_data_etl_batch_with_batch_source_value(
+        data_config=data_config,
+        initial_from_date=initial_from_date,
+        until_date=until_date,
+        all_source_values_iterator=all_source_values_iterator,
+        batch_source_value=None
+    )
 
 
 def get_next_batch_from_timestamp_for_config(

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -296,7 +296,8 @@ def iter_processed_web_api_data_etl_batch_data(
     data_config: WebApiConfig,
     initial_from_date: Optional[datetime] = None,
     until_date: Optional[datetime] = None,
-    all_source_values_iterator: Optional[Iterable[dict]] = None
+    all_source_values_iterator: Optional[Iterable[dict]] = None,
+    placeholder_values: Optional[dict] = None
 ) -> Iterable[dict]:
     assert not isinstance(all_source_values_iterator, list)
 
@@ -321,7 +322,8 @@ def iter_processed_web_api_data_etl_batch_data(
             data_config=data_config,
             initial_from_date=initial_from_date,
             fixed_until_date=until_date,
-            all_source_values_iterator=all_source_values_iterator
+            all_source_values_iterator=all_source_values_iterator,
+            placeholder_values=placeholder_values
         )
     )
     if not current_dynamic_request_parameters:

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -253,14 +253,12 @@ def get_next_dynamic_request_parameters_for_page_data(  # pylint: disable=too-ma
     ):
         LOGGER.info('End reached, no next cursor, page number, offset or from date')
         return None
-    return WebApiDynamicRequestParameters(
+    return current_dynamic_request_parameters._replace(
         from_date=from_date_to_advance or current_dynamic_request_parameters.from_date,
         to_date=variable_until_date,
         cursor=cursor,
         page_number=page_number,
-        page_offset=offset,
-        source_values=current_dynamic_request_parameters.source_values,
-        placeholder_values=current_dynamic_request_parameters.placeholder_values
+        page_offset=offset
     )
 
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -437,7 +437,8 @@ def process_web_api_data_etl_batch_with_batch_source_value(
                 LOGGER.info('updating state to: %r', latest_record_timestamp)
                 upload_latest_timestamp_as_pipeline_state(
                     data_config=data_config,
-                    latest_record_timestamp=latest_record_timestamp
+                    latest_record_timestamp=latest_record_timestamp,
+                    placeholder_values=batch_source_value
                 )
             else:
                 LOGGER.info('not updating state due to no latest record timestamp')

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -292,7 +292,7 @@ def get_initial_dynamic_request_parameters(
     )
 
 
-def iter_processed_web_api_data_etl_batch_data(
+def iter_processed_web_api_data_etl_batch_data(  # pylint: disable=too-many-locals
     data_config: WebApiConfig,
     initial_from_date: Optional[datetime] = None,
     until_date: Optional[datetime] = None,

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -259,7 +259,8 @@ def get_next_dynamic_request_parameters_for_page_data(  # pylint: disable=too-ma
         cursor=cursor,
         page_number=page_number,
         page_offset=offset,
-        source_values=current_dynamic_request_parameters.source_values
+        source_values=current_dynamic_request_parameters.source_values,
+        placeholder_values=current_dynamic_request_parameters.placeholder_values
     )
 
 

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -412,7 +412,8 @@ def process_web_api_data_etl_batch_with_batch_source_value(
         data_config=data_config,
         initial_from_date=initial_from_date,
         until_date=until_date,
-        all_source_values_iterator=all_source_values_iterator
+        all_source_values_iterator=all_source_values_iterator,
+        placeholder_values=batch_source_value
     )
     LOGGER.debug('all_processed_record_list: %r', all_processed_record_iterable)
     for batch_index, batch_processed_record_iterable in enumerate(iter_optional_batch_iterable(

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -78,13 +78,20 @@ webApi:
   - dataPipelineId: crossref_metadata_api
     dataset: '{ENV}'
     table: test_crossref_metadata_api_response
+    source:
+      include:
+        bigQuery:
+          projectName: 'elife-data-pipeline'
+          sqlQuery:
+            SELECT doi_prefix
+            FROM UNNEST(['10.31219', '10.31235']) AS doi_prefix
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
-      objectName: 'airflow-config/generic-web-api/{ENV}-crossref-metadata-state-10.31219.json'
+      objectName: 'airflow-config/generic-web-api/{ENV}-crossref-metadata-state-{doi_prefix}.json'
     urlSourceType:
       name: 'crossref_metadata_api'
     dataUrl:
-      urlExcludingConfigurableParameters: http://api.crossref.org/prefixes/10.31219/works?sort=indexed&order=asc
+      urlExcludingConfigurableParameters: http://api.crossref.org/prefixes/{doi_prefix}/works?sort=indexed&order=asc
       configurableParameters:
         nextPageCursorParameterName: 'cursor'
         fromDateParameterName: 'from-index-date'

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -87,7 +87,7 @@ webApi:
             FROM UNNEST(['10.31219', '10.31235']) AS doi_prefix
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
-      objectName: 'airflow-config/generic-web-api/{ENV}-crossref-metadata-state-{doi_prefix}.json'
+      objectName: 'airflow-config/generic-web-api/{ENV}-crossref-metadata-state/{doi_prefix}.json'
     urlSourceType:
       name: 'crossref_metadata_api'
     dataUrl:

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -904,7 +904,8 @@ class TestGenericWebApiDataEtl:
         generic_web_api_data_etl(data_config)
         upload_latest_timestamp_as_pipeline_state_mock.assert_called_with(
             data_config=data_config,
-            latest_record_timestamp=timestamp
+            latest_record_timestamp=timestamp,
+            placeholder_values=None
         )
 
     def test_should_not_update_state_with_empty_list_in_response(

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -779,6 +779,23 @@ class TestIterProcessedWebApiDataEtlBatchData:
         LOGGER.debug('record_list: %r', record_list)
         assert record_list == expected_combined_item_list_with_data
 
+    def test_should_pass_placeholder_values_to_request_parameters(
+        self,
+        get_data_single_page_response_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_CONFIG)
+        list(iter_processed_web_api_data_etl_batch_data(
+            data_config=data_config,
+            placeholder_values=PLACEHOLDER_VALUES_1
+        ))
+        get_data_single_page_response_mock.assert_called_with(
+            data_config=data_config,
+            dynamic_request_parameters=get_initial_dynamic_request_parameters(
+                data_config=data_config,
+                placeholder_values=PLACEHOLDER_VALUES_1
+            )
+        )
+
 
 class TestProcessWebApiDataEtlBatchWithBatchSourceValue:
     def test_should_pass_batch_source_values_as_placeholders_to_update_state(

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -646,6 +646,21 @@ class TestGetNextDynamicRequestParametersForPageData:
         assert next_dynamic_request_parameters
         assert next_dynamic_request_parameters.cursor == 'cursor_2'
 
+    def test_should_keep_placeholder_values_when_using_cursor(self):
+        data_config = _get_web_api_config_with_cursor_path(['next-cursor'])
+        initial_dynamic_request_parameters = WebApiDynamicRequestParameters(
+            cursor=None,
+            placeholder_values=PLACEHOLDER_VALUES_1
+        )
+        next_dynamic_request_parameters = get_next_dynamic_request_parameters_for_page_data(
+            page_data={'next-cursor': 'cursor_2'},
+            items_count=10,
+            current_dynamic_request_parameters=initial_dynamic_request_parameters,
+            data_config=data_config
+        )
+        assert next_dynamic_request_parameters
+        assert next_dynamic_request_parameters.placeholder_values == PLACEHOLDER_VALUES_1
+
     def test_should_return_next_source_values(self):
         data_config = get_data_config_with_max_source_values_per_request(
             get_data_config(WEB_API_CONFIG),

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -740,7 +740,7 @@ class TestIterProcessedWebApiDataEtlBatchData:
 
 
 class TestProcessWebApiDataEtlBatch:
-    def test_should_call_process_with_no_source_source_values_but_dates(
+    def test_should_pass_initial_and_until_date_to_process_with_batch_source_value_function(
         self,
         process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
     ):

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import dataclasses
 from datetime import datetime, timedelta
 import functools

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -631,7 +631,7 @@ class TestGetDataSinglePage:
         )
 
 
-class TestGetNextUrlComposeArgForPageData:
+class TestGetNextDynamicRequestParametersForPageData:
     def test_should_return_next_cursor(self):
         data_config = _get_web_api_config_with_cursor_path(['next-cursor'])
         initial_dynamic_request_parameters = WebApiDynamicRequestParameters(
@@ -686,7 +686,7 @@ class TestGetNextUrlComposeArgForPageData:
         assert next_dynamic_request_parameters is None
 
 
-class TestGetInitialUrlComposeArg:
+class TestGetInitialDynamicRequestParameters:
     def test_should_set_source_values_to_none_if_not_provided(self):
         initial_dynamic_request_parameters = get_initial_dynamic_request_parameters(
             data_config=get_data_config(WEB_API_CONFIG),

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -61,6 +61,7 @@ SOURCE_VALUE_2 = {'source': 'value 2'}
 
 PLACEHOLDER_VALUES_1 = {'placeholder': 'buddy1'}
 
+
 @pytest.fixture(name='requests_response_mock')
 def _requests_response_mock() -> MagicMock:
     response_mock = MagicMock(name='response_mock')
@@ -831,6 +832,7 @@ class TestProcessWebApiDataEtlBatchWithBatchSourceValue:
                 placeholder_values=SOURCE_VALUE_1
             )
         )
+
 
 class TestProcessWebApiDataEtlBatch:
     def test_should_pass_initial_and_until_date_to_process_with_batch_source_value_function(

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -815,6 +815,22 @@ class TestProcessWebApiDataEtlBatchWithBatchSourceValue:
             placeholder_values=SOURCE_VALUE_1
         )
 
+    def test_should_pass_batch_source_values_as_placeholders_in_request_parameters(
+        self,
+        get_data_single_page_response_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_CONFIG)
+        process_web_api_data_etl_batch_with_batch_source_value(
+            data_config=data_config,
+            batch_source_value=SOURCE_VALUE_1
+        )
+        get_data_single_page_response_mock.assert_called_with(
+            data_config=data_config,
+            dynamic_request_parameters=get_initial_dynamic_request_parameters(
+                data_config=data_config,
+                placeholder_values=SOURCE_VALUE_1
+            )
+        )
 
 class TestProcessWebApiDataEtlBatch:
     def test_should_pass_initial_and_until_date_to_process_with_batch_source_value_function(

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -59,6 +59,7 @@ TIMESTAMP_2 = datetime.fromisoformat(TIMESTAMP_STRING_2)
 SOURCE_VALUE_1 = {'source': 'value 1'}
 SOURCE_VALUE_2 = {'source': 'value 2'}
 
+PLACEHOLDER_VALUES_1 = {'placeholder': 'buddy1'}
 
 @pytest.fixture(name='requests_response_mock')
 def _requests_response_mock() -> MagicMock:
@@ -715,6 +716,20 @@ class TestGetInitialUrlComposeArg:
             all_source_values_iterator=all_source_values_iterator
         )
         assert initial_dynamic_request_parameters is None
+
+    def test_should_set_placeholder_values_to_none_by_default(self):
+        initial_dynamic_request_parameters = get_initial_dynamic_request_parameters(
+            data_config=get_data_config(WEB_API_CONFIG),
+            placeholder_values=None
+        )
+        assert initial_dynamic_request_parameters.placeholder_values is None
+
+    def test_should_pass_on_placeholder_values(self):
+        initial_dynamic_request_parameters = get_initial_dynamic_request_parameters(
+            data_config=get_data_config(WEB_API_CONFIG),
+            placeholder_values=PLACEHOLDER_VALUES_1
+        )
+        assert initial_dynamic_request_parameters.placeholder_values == PLACEHOLDER_VALUES_1
 
 
 class TestIterProcessedWebApiDataEtlBatchData:

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -766,7 +766,14 @@ class TestProcessWebApiDataEtlBatch:
         self,
         process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
     ):
-        data_config = get_data_config(WEB_API_CONFIG)
+        default_data_config = get_data_config(WEB_API_CONFIG)
+        data_config = dataclasses.replace(
+            default_data_config,
+            dynamic_request_builder=dataclasses.replace(
+                default_data_config.dynamic_request_builder,
+                max_source_values_per_request=2
+            )
+        )
         all_source_values_iterator = iter([SOURCE_VALUE_1])
         process_web_api_data_etl_batch(
             data_config=data_config,
@@ -780,6 +787,26 @@ class TestProcessWebApiDataEtlBatch:
             until_date=None,
             all_source_values_iterator=all_source_values_iterator,
             batch_source_value=None
+        )
+
+    def test_should_iterate_over_source_values_and_pass_on_batch_source_value(
+        self,
+        process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_CONFIG)
+        all_source_values_iterator = iter([SOURCE_VALUE_1])
+        process_web_api_data_etl_batch(
+            data_config=data_config,
+            initial_from_date=None,
+            until_date=None,
+            all_source_values_iterator=all_source_values_iterator
+        )
+        process_web_api_data_etl_batch_with_batch_source_value_mock.assert_called_with(
+            data_config=data_config,
+            initial_from_date=None,
+            until_date=None,
+            all_source_values_iterator=None,
+            batch_source_value=SOURCE_VALUE_1
         )
 
 

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -18,6 +18,7 @@ from data_pipeline.generic_web_api.generic_web_api_data_etl import (
     get_optional_total_count,
     iter_processed_web_api_data_etl_batch_data,
     process_web_api_data_etl_batch,
+    process_web_api_data_etl_batch_with_batch_source_value,
     upload_latest_timestamp_as_pipeline_state,
     get_items_list,
     get_next_cursor_from_data,
@@ -761,6 +762,25 @@ class TestIterProcessedWebApiDataEtlBatchData:
         ))
         LOGGER.debug('record_list: %r', record_list)
         assert record_list == expected_combined_item_list_with_data
+
+
+class TestProcessWebApiDataEtlBatchWithBatchSourceValue:
+    def test_should_pass_batch_source_values_as_placeholders_to_update_state(
+        self,
+        upload_latest_timestamp_as_pipeline_state_mock: MagicMock,
+        get_items_list_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_WITH_TIMESTAMP_FIELD_CONFIG_DICT)
+        get_items_list_mock.return_value = [{'timestamp': TIMESTAMP_STRING_1}]
+        process_web_api_data_etl_batch_with_batch_source_value(
+            data_config=data_config,
+            batch_source_value=SOURCE_VALUE_1
+        )
+        upload_latest_timestamp_as_pipeline_state_mock.assert_called_with(
+            data_config=ANY,
+            latest_record_timestamp=ANY,
+            placeholder_values=SOURCE_VALUE_1
+        )
 
 
 class TestProcessWebApiDataEtlBatch:

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -17,6 +17,7 @@ from data_pipeline.generic_web_api.generic_web_api_data_etl import (
     get_next_dynamic_request_parameters_for_page_data,
     get_optional_total_count,
     iter_processed_web_api_data_etl_batch_data,
+    process_web_api_data_etl_batch,
     upload_latest_timestamp_as_pipeline_state,
     get_items_list,
     get_next_cursor_from_data,
@@ -46,6 +47,12 @@ BIGQUERY_SOURCE_CONFIG_DICT_1 = {
 REQUEST_PROVENANCE_1 = {
     'api_url': 'url-1'
 }
+
+TIMESTAMP_STRING_1 = '2020-01-01+00:00'
+TIMESTAMP_STRING_2 = '2020-01-02+00:00'
+
+TIMESTAMP_1 = datetime.fromisoformat(TIMESTAMP_STRING_1)
+TIMESTAMP_2 = datetime.fromisoformat(TIMESTAMP_STRING_2)
 
 
 @pytest.fixture(name='requests_response_mock')
@@ -175,6 +182,14 @@ def _get_items_list_mock():
 def _iter_dict_for_bigquery_include_exclude_source_config_mock():
     with patch.object(
         generic_web_api_data_etl_module, 'iter_dict_for_bigquery_include_exclude_source_config'
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture(name='process_web_api_data_etl_batch_with_batch_source_value_mock')
+def _process_web_api_data_etl_batch_with_batch_source_value_mock():
+    with patch.object(
+        generic_web_api_data_etl_module, 'process_web_api_data_etl_batch_with_batch_source_value'
     ) as mock:
         yield mock
 
@@ -722,6 +737,27 @@ class TestIterProcessedWebApiDataEtlBatchData:
         ))
         LOGGER.debug('record_list: %r', record_list)
         assert record_list == expected_combined_item_list_with_data
+
+
+class TestProcessWebApiDataEtlBatch:
+    def test_should_call_process_with_no_source_source_values_but_dates(
+        self,
+        process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_CONFIG)
+        process_web_api_data_etl_batch(
+            data_config=data_config,
+            initial_from_date=TIMESTAMP_1,
+            until_date=TIMESTAMP_2,
+            all_source_values_iterator=None
+        )
+        process_web_api_data_etl_batch_with_batch_source_value_mock.assert_called_with(
+            data_config=data_config,
+            initial_from_date=TIMESTAMP_1,
+            until_date=TIMESTAMP_2,
+            all_source_values_iterator=None,
+            batch_source_value=None
+        )
 
 
 class TestGenericWebApiDataEtl:

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -54,6 +54,9 @@ TIMESTAMP_STRING_2 = '2020-01-02+00:00'
 TIMESTAMP_1 = datetime.fromisoformat(TIMESTAMP_STRING_1)
 TIMESTAMP_2 = datetime.fromisoformat(TIMESTAMP_STRING_2)
 
+SOURCE_VALUE_1 = {'source': 'value 1'}
+SOURCE_VALUE_2 = {'source': 'value 2'}
+
 
 @pytest.fixture(name='requests_response_mock')
 def _requests_response_mock() -> MagicMock:
@@ -756,6 +759,26 @@ class TestProcessWebApiDataEtlBatch:
             initial_from_date=TIMESTAMP_1,
             until_date=TIMESTAMP_2,
             all_source_values_iterator=None,
+            batch_source_value=None
+        )
+
+    def test_should_pass_all_source_values_iterator_to_process_with_batch_source_value_function(
+        self,
+        process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
+    ):
+        data_config = get_data_config(WEB_API_CONFIG)
+        all_source_values_iterator = iter([SOURCE_VALUE_1])
+        process_web_api_data_etl_batch(
+            data_config=data_config,
+            initial_from_date=None,
+            until_date=None,
+            all_source_values_iterator=all_source_values_iterator
+        )
+        process_web_api_data_etl_batch_with_batch_source_value_mock.assert_called_with(
+            data_config=data_config,
+            initial_from_date=None,
+            until_date=None,
+            all_source_values_iterator=all_source_values_iterator,
             batch_source_value=None
         )
 

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -762,7 +762,7 @@ class TestProcessWebApiDataEtlBatch:
             batch_source_value=None
         )
 
-    def test_should_pass_all_source_values_iterator_to_process_with_batch_source_value_function(
+    def test_should_pass_on_all_source_values_iterator_if_should_not_iterate_over_source_values(
         self,
         process_web_api_data_etl_batch_with_batch_source_value_mock: MagicMock
     ):

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -135,6 +135,19 @@ class TestCrossrefMetadataWebApiDynamicRequestBuilder:
         params = parse_qs(url.query)
         assert params.get('filter') == ['from-index-date:2024-01-29,until-index-date:2024-01-30']
 
+    def test_should_replace_placeholders(self):
+        dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1 + '/{placeholder}',
+            static_parameters={}
+        )
+        url = dynamic_request_builder.get_url(
+            dynamic_request_parameters=WebApiDynamicRequestParameters(
+                placeholder_values={'placeholder': 'buddy1'}
+            )
+        )
+        LOGGER.debug('url: %r', url)
+        assert url.rstrip('?') == TEST_API_URL_1 + '/buddy1'
+
 
 class TestDynamicS2TitleAbstractEmbeddingsURLBuilder:
     def test_should_set_method_to_post(self):


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/854

This is to allow ingesting from multiple Crossref prefixes, with the same Web API pipeline (rather than copying it).

It is using the existing BigQuery source values to configure the list of DOI prefixes.