### PR TITLE
Revert "Reduce CSV pipeline memory usage"

### DIFF
--- a/data_pipeline/s3_csv_data/s3_csv_etl.py
+++ b/data_pipeline/s3_csv_data/s3_csv_etl.py
@@ -7,7 +7,7 @@ import csv
 from csv import DictReader
 import json
 from datetime import datetime
-from typing import Iterable, Optional
+from typing import Optional
 
 from botocore.exceptions import ClientError
 from dateutil import tz
@@ -23,8 +23,10 @@ from data_pipeline.spreadsheet_data.google_spreadsheet_etl import (
 )
 from data_pipeline.utils.data_store.s3_data_service import (
     download_s3_json_object,
-    s3_open_binary_read,
     upload_s3_object
+)
+from data_pipeline.utils.data_store.s3_data_service import (
+    download_s3_object_as_string
 )
 from data_pipeline.utils.record_processing import (
     process_record_values, DEFAULT_PROCESSING_STEPS
@@ -113,6 +115,13 @@ def get_stored_state(
     }
 
 
+def get_csv_data_from_s3(s3_bucket_name: str, s3_object_name: str):
+
+    return download_s3_object_as_string(
+        s3_bucket_name, s3_object_name
+    )
+
+
 def get_sorted_in_sheet_metadata_index(csv_config: S3BaseCsvConfig):
     record_metadata = [
         {line_index_in_data: metadata_col_name}
@@ -193,65 +202,39 @@ def update_metadata_with_provenance(
     }
 
 
-def iter_transformed_json_from_csv(
-    s3_object_name: str,
-    csv_config: S3BaseCsvConfig,
-    record_import_timestamp_as_string: str,
-) -> Iterable[dict]:
+def transform_load_data(
+        s3_object_name: str,
+        csv_config: S3BaseCsvConfig,
+        record_import_timestamp_as_string: str,
+):
     default_value_processing_function_steps = (
         [*DEFAULT_PROCESSING_STEPS]
     )
     LOGGER.info('processing object: "%s"', s3_object_name)
-
-    with s3_open_binary_read(
-        csv_config.s3_bucket_name,
-        s3_object_name
-    ) as streaming_body:
-        LOGGER.debug('streaming_body: %s', streaming_body)
-        text_stream = io.TextIOWrapper(streaming_body, 'utf-8')
-        header_lines = [
-            text_stream.readline() for _ in range(csv_config.data_values_start_line_index or 1)
-        ]
-        LOGGER.debug('header_lines: %s', header_lines)
-        record_metadata = get_record_metadata(
-            header_lines,
-            csv_config,
-            s3_object_name,
-            record_import_timestamp_as_string
-        )
-
-        standardized_csv_header = get_standardized_csv_header(
-            header_lines,
-            csv_config
-        )
-        LOGGER.debug('standardized_csv_header: %s', standardized_csv_header)
-
-        csv_dict_reader = csv.DictReader(
-            text_stream,
-            fieldnames=standardized_csv_header
-        )
-        if csv_config.record_processing_function_steps:
-            default_value_processing_function_steps.extend(
-                csv_config.record_processing_function_steps
-            )
-        processed_record_iterable = process_record_list(
-            csv_dict_reader,
-            record_metadata,
-            default_value_processing_function_steps
-        )
-
-        return processed_record_iterable
-
-
-def transform_load_data(
-    s3_object_name: str,
-    csv_config: S3BaseCsvConfig,
-    record_import_timestamp_as_string: str,
-):
-    processed_record_iterable = iter_transformed_json_from_csv(
-        s3_object_name,
-        csv_config,
+    csv_string = get_csv_data_from_s3(
+        csv_config.s3_bucket_name, s3_object_name
+    )
+    record_list = csv_string.split("\n")
+    record_metadata = get_record_metadata(
+        record_list, csv_config, s3_object_name,
         record_import_timestamp_as_string
+    )
+    standardized_csv_header = get_standardized_csv_header(
+        record_list, csv_config
+    )
+
+    csv_dict_reader = get_csv_dict_reader(
+        csv_string,
+        standardized_csv_header,
+        csv_config
+    )
+    if csv_config.record_processing_function_steps:
+        default_value_processing_function_steps.extend(
+            csv_config.record_processing_function_steps
+        )
+    processed_record = process_record_list(
+        csv_dict_reader, record_metadata,
+        default_value_processing_function_steps
     )
 
     with TemporaryDirectory() as tmp_dir:
@@ -259,8 +242,7 @@ def transform_load_data(
             Path(tmp_dir, "downloaded_jsonl_data")
         )
         write_jsonl_to_file(
-            processed_record_iterable,
-            full_temp_file_location
+            processed_record, full_temp_file_location
         )
 
         if os.path.getsize(full_temp_file_location) > 0:

--- a/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
@@ -1,15 +1,13 @@
-import io
 import os
 from collections import OrderedDict
 from typing import Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import pytest
 import botocore
 
 from data_pipeline.s3_csv_data import s3_csv_etl
 from data_pipeline.s3_csv_data.s3_csv_etl import (
     get_record_metadata,
-    iter_transformed_json_from_csv,
     transform_load_data,
     get_standardized_csv_header,
     process_record_list,
@@ -42,13 +40,11 @@ def _os_stat():
         yield mock
 
 
-@pytest.fixture(name="mock_s3_open_binary_read", autouse=True)
-def _s3_open_binary_read():
+@pytest.fixture(name="mock_get_csv_data_from_s3", autouse=True)
+def _get_csv_data_from_s3():
     with patch.object(s3_csv_etl,
-                      "s3_open_binary_read") as mock:
-        mock.return_value.__enter__.return_value = io.BytesIO(
-            TEST_DOWNLOADED_SHEET.encode('utf-8')
-        )
+                      "get_csv_data_from_s3") as mock:
+        mock.return_value = TEST_DOWNLOADED_SHEET
 
         yield mock
 
@@ -60,14 +56,14 @@ def _create_or_extend_table_schema():
         yield mock
 
 
-@pytest.fixture(name="mock_get_csv_dict_reader")
+@pytest.fixture(name="mock_get_csv_dict_reader", autouse=True)
 def _get_csv_dict_reader():
     with patch.object(s3_csv_etl,
                       "get_csv_dict_reader") as mock:
         yield mock
 
 
-@pytest.fixture(name="mock_process_record_list")
+@pytest.fixture(name="mock_process_record_list", autouse=True)
 def _process_record_list():
     with patch.object(s3_csv_etl,
                       "process_record_list") as mock:
@@ -108,21 +104,6 @@ def _write_to_file():
     with patch.object(s3_csv_etl,
                       "write_jsonl_to_file") as mock:
         yield mock
-
-
-MINIMAL_CSV_CONFIG_DICT = {
-    'dataValuesStartLineIndex': 1
-}
-
-
-def get_s3_csv_config(csv_config_dict: dict):
-    gcp_project = ""
-    deployment_env = ""
-    return S3BaseCsvConfig(
-        csv_config_dict,
-        gcp_project,
-        deployment_env
-    )
 
 
 class TestSheetRecordMetadata:
@@ -326,61 +307,6 @@ class TestCsvHeader:
         assert standardized_header_result == expected_result
 
 
-class TestIterTransformedJsonFromCsv:
-    def test_should_transform_a_simple_csv_file(
-        self,
-        mock_s3_open_binary_read: MagicMock
-    ):
-        mock_s3_open_binary_read.return_value.__enter__.return_value = io.BytesIO(
-            '\n'.join(['name,age', 'hazal,6']).encode('utf-8')
-        )
-        minimal_csv_config = get_s3_csv_config(MINIMAL_CSV_CONFIG_DICT)
-        record_import_timestamp_as_string = ""
-        s3_object_name = "s3_object"
-        actual_result = list(iter_transformed_json_from_csv(
-            s3_object_name,
-            minimal_csv_config,
-            record_import_timestamp_as_string
-        ))
-        expected_result = [{
-            'name': 'hazal',
-            'age': '6',
-            'provenance': {'s3_bucket': '', 'source_filename': 's3_object'}
-        }]
-        assert actual_result == expected_result
-
-    def test_should_transform_a_csv_file_with_metadata(
-        self,
-        mock_s3_open_binary_read: MagicMock
-    ):
-        mock_s3_open_binary_read.return_value.__enter__.return_value = io.BytesIO(
-            '\n'.join(['metadata', 'name,age', 'hazal,6']).encode('utf-8')
-        )
-        minimal_csv_config = get_s3_csv_config({
-            **MINIMAL_CSV_CONFIG_DICT,
-            'dataValuesStartLineIndex': 2,
-            'headerLineIndex': 1,
-            'inSheetRecordMetadata': [{
-                'metadataSchemaFieldName': 'metadata_field',
-                'metadataLineIndex': 0
-            }]
-        })
-        record_import_timestamp_as_string = ""
-        s3_object_name = "s3_object"
-        actual_result = list(iter_transformed_json_from_csv(
-            s3_object_name,
-            minimal_csv_config,
-            record_import_timestamp_as_string
-        ))
-        expected_result = [{
-            'name': 'hazal',
-            'age': '6',
-            'provenance': {'s3_bucket': '', 'source_filename': 's3_object'},
-            'metadata_field': 'metadata'
-        }]
-        assert actual_result == expected_result
-
-
 class TestTransformAndLoadData:
     @staticmethod
     def get_csv_config(update_dict: Optional[dict] = None):
@@ -416,6 +342,7 @@ class TestTransformAndLoadData:
 
     def test_should_transform_write_and_load_to_bq(
             self,
+            mock_get_csv_dict_reader,
             mock_process_record_list,
             mock_load_file_into_bq
     ):
@@ -426,6 +353,7 @@ class TestTransformAndLoadData:
             TestTransformAndLoadData.get_csv_config(),
             record_import_timestamp_as_string,
         )
+        mock_get_csv_dict_reader.assert_called()
         mock_process_record_list.assert_called()
         mock_load_file_into_bq.assert_called()
 


### PR DESCRIPTION
Reverts elifesciences/data-hub-core-airflow-dags#1421

Changes made in: https://github.com/elifesciences/data-hub-issues/issues/904

Reverting back until solve the problem:

```
[2024-04-10, 15:55:27 UTC] {taskinstance.py:1935} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 192, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/operators/python.py", line 209, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/opt/airflow/dags/dags/s3_csv_import_pipeline.py", line 115, in csv_etl
    etl_new_csv_files(data_config=data_config)
  File "/opt/airflow/dags/dags/s3_csv_import_pipeline.py", line 88, in etl_new_csv_files
    transform_load_data(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/s3_csv_data/s3_csv_etl.py", line 261, in transform_load_data
    write_jsonl_to_file(
  File "/opt/airflow/git_repos/core_dag/data_pipeline/utils/pipeline_file_io.py", line 32, in write_jsonl_to_file
    for record in json_list:
  File "/opt/airflow/git_repos/core_dag/data_pipeline/s3_csv_data/s3_csv_etl.py", line 296, in process_record_list
    for record in reader:
  File "/usr/local/lib/python3.8/csv.py", line 111, in __next__
    row = next(self.reader)
  File "/home/airflow/.local/lib/python3.8/site-packages/botocore/response.py", line 110, in read
    self._verify_content_length()
  File "/home/airflow/.local/lib/python3.8/site-packages/botocore/response.py", line 167, in _verify_content_length
    raise IncompleteReadError(
botocore.exceptions.IncompleteReadError: 8192 read, but total bytes expected is 74408.
```