### PR TITLE
Fixed GA UA pipeline failing when no annotation are configured

### DIFF
--- a/data_pipeline/google_analytics/ga_pipeline.py
+++ b/data_pipeline/google_analytics/ga_pipeline.py
@@ -19,6 +19,7 @@ from data_pipeline.google_analytics.etl_state import (
 from data_pipeline.utils.data_store.google_analytics import (
     GoogleAnalyticsClient
 )
+from data_pipeline.utils.json import remove_key_with_null_value
 from data_pipeline.utils.progress import ProgressMonitor
 
 LOGGER = logging.getLogger(__name__)
@@ -146,10 +147,10 @@ def add_provenance(
     provenance_containing_dict: dict
 ) -> Iterable[dict]:
     for record in ga_records:
-        yield {
+        yield remove_key_with_null_value({
             **record,
             **provenance_containing_dict
-        }
+        })
 
 
 def iter_bq_records_for_paged_report_response(


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/8412

It was failing with:

> google.api_core.exceptions.BadRequest: 400 Error while reading data, error message: JSON table encountered too many errors, giving up. Rows: 1; errors: 1. Please look into the errors[] collection for more details.; Error while reading data, error message: JSON processing encountered too many errors, giving up. Rows: 1; errors: 1; max bad: 0; error percent: 0; Error while reading data, error message: JSON parsing error in row starting at position 0: No such field: provenance.annotation.

(It doesn't seem to have failed with an existing table defining the schema for annotations)