### PR TITLE
CSV Pipeline: Parse executor config pod override

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[crypto,celery,postgres,jdbc,ssh]==2.7.1
+apache-airflow[crypto,celery,cncf,postgres,jdbc,ssh]==2.7.1
 apache-airflow-providers-amazon==7.3.0
 backoff==2.2.1
 bigquery-schema-generator==1.6.1
@@ -9,6 +9,7 @@ botocore==1.27.59
 cattrs==23.2.3
 cloudpickle==3.0.0
 dateparser==1.2.0
+kubernetes==23.6.0
 objsize==0.7.0
 regex==2023.12.25
 fsspec==2022.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[crypto,celery,cncf,postgres,jdbc,ssh]==2.7.1
+apache-airflow[crypto,celery,postgres,jdbc,ssh]==2.7.1
 apache-airflow-providers-amazon==7.3.0
 backoff==2.2.1
 bigquery-schema-generator==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ cattrs==23.2.3
 cloudpickle==3.0.0
 dateparser==1.2.0
 kubernetes==23.6.0
+apache-airflow-providers-cncf-kubernetes==7.5.0
 objsize==0.7.0
 regex==2023.12.25
 fsspec==2022.8.2

--- a/tests/unit_test/utils/pipeline_config_test.py
+++ b/tests/unit_test/utils/pipeline_config_test.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from kubernetes.client.models.v1_pod import V1Pod
+
 from data_pipeline.utils.pipeline_config import (
     SECRET_VALUE_PLACEHOLDER,
     AirflowConfig,
@@ -206,6 +208,23 @@ class TestAirflowConfig:
             'queue': 'updated-queue',
             'new-key': 'value'
         }
+
+    def test_should_parse_pod_override_into_kubernetes_v1_pod(self):
+        config = AirflowConfig.from_dict({
+            'taskParameters': {
+                'executor_config': {
+                    'pod_override': {
+                        'spec': {
+                            'containers': [{
+                                'name': 'base'
+                            }]
+                        }
+                    }
+                }
+            }
+        })
+        pod_override = config.task_parameters['executor_config']['pod_override']
+        assert isinstance(pod_override, V1Pod)
 
 
 class TestStrToBool:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/843

See https://github.com/elifesciences/elife-flux-cluster/pull/2804

Airflow expects the `pod_override`, if provided, to be an instance of V1Pod.
We are parsing the dict from the config into a V1Pod.