### PR TITLE
Web API: Use airflow config to enable running in Kubernetes and individual schedule

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_config_typing.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config_typing.py
@@ -2,6 +2,7 @@ from typing import Sequence
 from typing_extensions import NotRequired, TypedDict
 
 from data_pipeline.utils.pipeline_config_typing import (
+    AirflowConfigDict,
     BigQueryIncludeExcludeSourceConfigDict,
     MappingConfigDict,
     ParameterFromFileConfigDict,
@@ -75,6 +76,7 @@ class WebApiResponseConfigDict(TypedDict):
 
 class WebApiBaseConfigDict(TypedDict):
     dataPipelineId: str
+    airflow: NotRequired[AirflowConfigDict]
     description: NotRequired[str]
     dataset: str
     table: str


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/646
related to https://github.com/elifesciences/data-hub-issues/issues/843

Apply the same change we previously applied to the CSV pipeline, also to the Web API pipeline.