### PR TITLE
Move csv and web default airflow config to yaml config

### DIFF
--- a/dags/s3_csv_import_pipeline.py
+++ b/dags/s3_csv_import_pipeline.py
@@ -1,10 +1,10 @@
 # Note: DagBag.process_file skips files without "airflow" or "DAG" in them
 
+from datetime import timedelta
 import functools
 import os
 import logging
-from datetime import timedelta
-from typing import Optional, Sequence
+from typing import Sequence
 
 import airflow
 from airflow.exceptions import AirflowSkipException
@@ -34,7 +34,6 @@ from data_pipeline.utils.data_pipeline_timestamp import (
 )
 from data_pipeline.utils.pipeline_config import (
     AirflowConfig,
-    get_environment_variable_value,
     get_pipeline_config_for_env_name_and_config_parser
 )
 
@@ -44,9 +43,6 @@ INITIAL_S3_FILE_LAST_MODIFIED_DATE_ENV_NAME = (
     "INITIAL_S3_FILE_LAST_MODIFIED_DATE"
 )
 
-S3_CSV_SCHEDULE_INTERVAL_ENV_NAME = (
-    "S3_CSV_SCHEDULE_INTERVAL"
-)
 S3_CSV_CONFIG_FILE_PATH_ENV_NAME = (
     "S3_CSV_CONFIG_FILE_PATH"
 )
@@ -120,17 +116,10 @@ def get_dag_id_for_s3_csv_config_dict(s3_csv_config_dict: S3CsvConfigDict) -> st
     return f'CSV.{s3_csv_config_dict["dataPipelineId"]}'
 
 
-def create_csv_pipeline_dags(
-    default_schedule: Optional[str] = None
-) -> Sequence[airflow.DAG]:
+def create_csv_pipeline_dags() -> Sequence[airflow.DAG]:
     dags = []
     multi_csv_pipeline_config = get_multi_csv_pipeline_config()
-    default_airflow_config = AirflowConfig(
-        dag_parameters={
-            'schedule': default_schedule,
-            'dagrun_timeout': timedelta(days=1),
-        }
-    )
+    default_airflow_config = multi_csv_pipeline_config.default_airflow_config
     for data_pipeline_id, s3_csv_config_dict in (
         multi_csv_pipeline_config.s3_csv_config_dict_by_pipeline_id.items()
     ):
@@ -141,6 +130,7 @@ def create_csv_pipeline_dags(
         with create_dag(
             dag_id=get_dag_id_for_s3_csv_config_dict(s3_csv_config_dict),
             description=s3_csv_config_dict.get('description'),
+            dagrun_timeout=timedelta(days=1),
             **airflow_config.dag_parameters
         ) as dag:
             create_python_task(
@@ -163,13 +153,6 @@ def get_default_initial_s3_last_modified_date():
     )
 
 
-def get_default_schedule() -> Optional[str]:
-    return get_environment_variable_value(
-        S3_CSV_SCHEDULE_INTERVAL_ENV_NAME,
-        default_value=None
-    )
-
-
-DAGS = create_csv_pipeline_dags(default_schedule=get_default_schedule())
+DAGS = create_csv_pipeline_dags()
 
 FIRST_DAG = DAGS[0]

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -10,6 +10,7 @@ from data_pipeline.generic_web_api.request_builder import (
 )
 from data_pipeline.generic_web_api.web_api_auth import WebApiAuthentication
 from data_pipeline.utils.pipeline_config import (
+    AirflowConfig,
     BigQueryIncludeExcludeSourceConfig,
     ConfigKeys,
     MappingConfig,
@@ -70,6 +71,10 @@ class MultiWebApiConfig:
         self.gcp_project = multi_web_api_etl_config.get("gcpProjectName")
         self.import_timestamp_field_name = multi_web_api_etl_config.get(
             "importedTimestampFieldName"
+        )
+        default_config_dict = multi_web_api_etl_config.get('defaultConfig', {})
+        self.default_airflow_config = AirflowConfig.from_optional_dict(
+            default_config_dict.get('airflow')
         )
         self.web_api_config: Mapping[int, WebApiConfigDict] = {
             ind: cast(WebApiConfigDict, {

--- a/data_pipeline/generic_web_api/generic_web_api_config_typing.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config_typing.py
@@ -101,5 +101,10 @@ class WebApiConfigDict(WebApiBaseConfigDict, WebApiGlobalConfigDict):
     pass
 
 
+class MultiWebApiDefaultConfigDict(TypedDict):
+    airflow: NotRequired[AirflowConfigDict]
+
+
 class MultiWebApiConfigDict(WebApiGlobalConfigDict):
+    defaultConfig: NotRequired[MultiWebApiDefaultConfigDict]
     webApi: Sequence[WebApiBaseConfigDict]

--- a/data_pipeline/s3_csv_data/s3_csv_config.py
+++ b/data_pipeline/s3_csv_data/s3_csv_config.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from data_pipeline.utils.csv.config import BaseCsvConfig
 from data_pipeline.utils.pipeline_config import (
+    AirflowConfig,
     update_deployment_env_placeholder
 )
 
@@ -16,6 +17,10 @@ class MultiS3CsvConfig:
                  ):
         self.gcp_project = multi_s3_csv_config["gcpProjectName"]
         self.import_timestamp_field_name = multi_s3_csv_config["importedTimestampFieldName"]
+        default_config_dict = multi_s3_csv_config.get('defaultConfig', {})
+        self.default_airflow_config = AirflowConfig.from_optional_dict(
+            default_config_dict.get('airflow')
+        )
         self.s3_csv_config = [
             extend_s3_csv_config_with_state_file_info(
                 extend_s3_csv_config_dict(

--- a/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
+++ b/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
@@ -3,6 +3,28 @@ importedTimestampFieldName: "imported_timestamp"
 stateFile:
   defaultBucketName: ci-elife-data-pipeline
   defaultSystemGeneratedObjectPrefix: "airflow-config/{ENV}-s3-csv/state/s3-csv"
+
+defaultConfig:
+  airflow:
+    dagParameters:
+      # schedule: '@daily'
+      tags:
+        - 'CSV'
+    # taskParameters:
+    #   queue: 'kubernetes'
+    #   executor_config:
+    #     pod_override:
+    #       spec:
+    #         containers:
+    #           - name: 'base'
+    #             resources:
+    #               limits:
+    #                 memory: 1gb
+    #                 cpu: 1000m
+    #               requests:
+    #                 memory: 1gb
+    #                 cpu: 100m
+
 s3Csv:
   # Note: the first configuration is used by the end2end test
 

--- a/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
+++ b/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
@@ -100,9 +100,12 @@ s3Csv:
       objectName: "airflow_test/state/s3-csv/state-sciety-events.json"
     recordProcessingSteps:
       - parse_json_value
-    # airflow:
-    #   dagParameters:
-    #     schedule: '@daily'
+    airflow:
+      dagParameters:
+        # schedule: '@daily'
+        tags:
+          - 'CSV'
+          - 'Sciety'
     #   taskParameters:
     #     queue: 'kubernetes'
     #     executor_config:

--- a/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
+++ b/sample_data_config/s3-csv/s3-csv-data-pipeline.config.yaml
@@ -19,10 +19,10 @@ defaultConfig:
     #           - name: 'base'
     #             resources:
     #               limits:
-    #                 memory: 1gb
+    #                 memory: 1Gi
     #                 cpu: 1000m
     #               requests:
-    #                 memory: 1gb
+    #                 memory: 1Gi
     #                 cpu: 100m
 
 s3Csv:
@@ -112,8 +112,8 @@ s3Csv:
     #             - name: 'base'
     #               resources:
     #                 limits:
-    #                   memory: 1gb
+    #                   memory: 1Gi
     #                   cpu: 1000m
     #                 requests:
-    #                   memory: 1gb
+    #                   memory: 1Gi
     #                   cpu: 100m

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -1,5 +1,13 @@
 gcpProjectName: 'elife-data-pipeline'
 importedTimestampFieldName: 'data_hub_imported_timestamp'
+
+defaultConfig:
+  airflow:
+    dagParameters:
+      # schedule: '@daily'
+      tags:
+        - 'Web API'
+
 webApi:
   # Note: the first configuration is used by the end2end test
 

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from data_pipeline.generic_web_api.request_builder import CiviWebApiDynamicRequestBuilder
-from data_pipeline.utils.pipeline_config import BigQueryIncludeExcludeSourceConfig, ConfigKeys
+from data_pipeline.utils.pipeline_config import (
+    AirflowConfig,
+    BigQueryIncludeExcludeSourceConfig,
+    ConfigKeys
+)
 
 from data_pipeline.generic_web_api import generic_web_api_config as generic_web_api_config_module
 from data_pipeline.generic_web_api.generic_web_api_config import (
@@ -16,11 +20,18 @@ from data_pipeline.generic_web_api.generic_web_api_config import (
 from data_pipeline.generic_web_api.generic_web_api_config_typing import (
     WebApiResponseConfigDict
 )
+from data_pipeline.utils.pipeline_config_typing import AirflowConfigDict
 from tests.unit_test.generic_web_api.test_data import (
     DATASET_1,
     MINIMAL_WEB_API_CONFIG_DICT,
     TABLE_1
 )
+
+
+AIRFLOW_CONFIG_DICT_1: AirflowConfigDict = {
+    'dagParameters': {'schedule': 'some-schedule'},
+    'taskParameters': {'queue': 'some-queue'}
+}
 
 
 BIGQUERY_SOURCE_CONFIG_DICT_1 = {
@@ -82,6 +93,17 @@ class TestMultiWebApiConfig:
         assert multi_web_api_config.web_api_config[0][
             ConfigKeys.DATA_PIPELINE_CONFIG_ID
         ] == 'table1_0'
+
+    def test_should_read_default_airflow_config(self):
+        multi_config = MultiWebApiConfig({
+            'defaultConfig': {
+                'airflow': AIRFLOW_CONFIG_DICT_1
+            },
+            'webApi': []
+        })
+        assert multi_config.default_airflow_config == AirflowConfig.from_dict(
+            AIRFLOW_CONFIG_DICT_1
+        )
 
 
 class TestWebApiResponseConfig:

--- a/tests/unit_test/s3_csv_data/s3_csv_config_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_config_test.py
@@ -11,9 +11,24 @@ from data_pipeline.utils.csv.metadata_schema import (
 )
 
 from data_pipeline.utils.pipeline_config import (
+    AirflowConfig,
     update_deployment_env_placeholder
 )
-from data_pipeline.s3_csv_data.s3_csv_config import S3BaseCsvConfig
+from data_pipeline.s3_csv_data.s3_csv_config import MultiS3CsvConfig, S3BaseCsvConfig
+from data_pipeline.utils.pipeline_config_typing import AirflowConfigDict
+
+
+AIRFLOW_CONFIG_DICT_1: AirflowConfigDict = {
+    'dagParameters': {'schedule': 'some-schedule'},
+    'taskParameters': {'queue': 'some-queue'}
+}
+
+
+MINIMAL_MULTI_S3_CSV_CONFIG_DICT = {
+    'gcpProjectName': 'gcpProjectName_1',
+    'importedTimestampFieldName': 'importedTimestampFieldName_1',
+    's3Csv': []
+}
 
 
 @pytest.fixture(name="mock_extend_table_schema_with_nested_schema")
@@ -57,6 +72,22 @@ class TestData:
             "deployment_env"
         )
         return config
+
+
+class TestMultiS3CsvConfig:
+    def test_should_should_not_fail_with_minimal_config(self):
+        MultiS3CsvConfig(MINIMAL_MULTI_S3_CSV_CONFIG_DICT)
+
+    def test_should_read_default_airflow_config(self):
+        multi_config = MultiS3CsvConfig({
+            **MINIMAL_MULTI_S3_CSV_CONFIG_DICT,
+            'defaultConfig': {
+                'airflow': AIRFLOW_CONFIG_DICT_1
+            }
+        })
+        assert multi_config.default_airflow_config == AirflowConfig.from_dict(
+            AIRFLOW_CONFIG_DICT_1
+        )
 
 
 class TestMetadataSchema:


### PR DESCRIPTION
This allows us for example to run all CSV pipeline via the KubernetesExecutor.