### PR TITLE
GA UA Use AirflowConfig to support running via Kubernetes exector

### DIFF
--- a/dags/google_analytics_data_import_pipeline.py
+++ b/dags/google_analytics_data_import_pipeline.py
@@ -1,6 +1,5 @@
 # Note: DagBag.process_file skips files without "airflow" or "DAG" in them
 
-import os
 import logging
 from datetime import timedelta
 from typing import Sequence

--- a/data_pipeline/google_analytics/ga_config.py
+++ b/data_pipeline/google_analytics/ga_config.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from data_pipeline.utils.data_store.google_analytics import DEFAULT_PAGE_SIZE
 from data_pipeline.utils.pipeline_config import (
+    AirflowConfig,
     update_deployment_env_placeholder
 )
 # pylint: disable=too-few-public-methods,simplifiable-if-expression,
@@ -37,6 +38,10 @@ class MultiGoogleAnalyticsConfig:
                 deployment_env,
                 deployment_env_placeholder
             ) if deployment_env else multi_google_analytics_config
+        )
+        default_config_dict = updated_config.get('defaultConfig', {})
+        self.default_airflow_config = AirflowConfig.from_optional_dict(
+            default_config_dict.get('airflow')
         )
         self.gcp_project = updated_config[
             "gcpProjectName"

--- a/sample_data_config/google-analytics/ga-data-pipeline.config.yaml
+++ b/sample_data_config/google-analytics/ga-data-pipeline.config.yaml
@@ -1,5 +1,29 @@
 gcpProjectName: 'elife-data-pipeline'
 importedTimestampFieldName: 'data_hub_imported_timestamp'
+
+defaultConfig:
+  airflow:
+    dagParameters:
+      # schedule: '@daily'
+      tags:
+        - 'GA'
+        - 'UA'
+    taskParameters:
+      retries: 1
+    #   queue: 'kubernetes'
+    #   executor_config:
+    #     pod_override:
+    #       spec:
+    #         containers:
+    #           - name: 'base'
+    #             resources:
+    #               limits:
+    #                 memory: 1Gi
+    #                 cpu: 1000m
+    #               requests:
+    #                 memory: 1Gi
+    #                 cpu: 100m
+
 googleAnalyticsPipelines:
   - pipelineID: '{ENV}-some-pipeline-id'
     # defaultStartDate: "2014-11-07"

--- a/sample_data_config/google-analytics/ga-data-pipeline.config.yaml
+++ b/sample_data_config/google-analytics/ga-data-pipeline.config.yaml
@@ -5,6 +5,7 @@ defaultConfig:
   airflow:
     dagParameters:
       # schedule: '@daily'
+      schedule: null
       tags:
         - 'GA'
         - 'UA'


### PR DESCRIPTION
Related to https://github.com/elifesciences/issues/issues/8759

Still running sequentially as a single DAG to avoid issues relating to concurrent API access.

This should help not getting killed midway.