### PR TITLE
OpenSearch: Ingest pipeline support

### DIFF
--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -54,15 +54,15 @@ class BigQueryToOpenSearchSourceConfig:
 
 
 @dataclass(frozen=True)
-class OpenSearchIngestionPipelineConfig:
+class OpenSearchIngestPipelineConfig:
     name: str
     definition:  str
 
     @staticmethod
     def from_dict(
         ingestion_pipeline_config_dict: OpenSearchIngestionPipelineConfigDict
-    ) -> 'OpenSearchIngestionPipelineConfig':
-        return OpenSearchIngestionPipelineConfig(
+    ) -> 'OpenSearchIngestPipelineConfig':
+        return OpenSearchIngestPipelineConfig(
             name=ingestion_pipeline_config_dict['name'],
             definition=ingestion_pipeline_config_dict['definition']
         )
@@ -70,9 +70,9 @@ class OpenSearchIngestionPipelineConfig:
     @staticmethod
     def from_dict_list(
         ingestion_pipeline_config_dict_list: Sequence[OpenSearchIngestionPipelineConfigDict]
-    ) -> Sequence['OpenSearchIngestionPipelineConfig']:
+    ) -> Sequence['OpenSearchIngestPipelineConfig']:
         return list(map(
-            OpenSearchIngestionPipelineConfig.from_dict,
+            OpenSearchIngestPipelineConfig.from_dict,
             ingestion_pipeline_config_dict_list
         ))
 
@@ -88,7 +88,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
     update_index_settings: bool = False
     update_mappings: bool = False
     index_settings: Optional[dict] = None
-    ingestion_pipelines: Sequence[OpenSearchIngestionPipelineConfig] = field(default_factory=list)
+    ingest_pipelines: Sequence[OpenSearchIngestPipelineConfig] = field(default_factory=list)
     verify_certificates: bool = True
     operation_mode: str = DEFAULT_OPENSEARCH_OPERATION_MODE
     upsert: bool = False
@@ -117,7 +117,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
             timeout=opensearch_target_config_dict.get('timeout', DEFAULT_OPENSEARCH_TIMEOUT),
             update_index_settings=opensearch_target_config_dict.get('updateIndexSettings', False),
             update_mappings=opensearch_target_config_dict.get('updateMappings', False),
-            ingestion_pipelines=OpenSearchIngestionPipelineConfig.from_dict_list(
+            ingest_pipelines=OpenSearchIngestPipelineConfig.from_dict_list(
                 opensearch_target_config_dict.get('ingestionPipelines', [])
             ),
             index_settings=opensearch_target_config_dict.get('indexSettings'),

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -3,6 +3,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import Optional, Sequence
 
+from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
+    OpenSearchIngestionPipelineConfigDict
+)
 from data_pipeline.utils.pipeline_config import (
     BigQuerySourceConfig,
     StateFileConfig,
@@ -46,6 +49,21 @@ class BigQueryToOpenSearchSourceConfig:
             bigquery=BigQuerySourceConfig.from_dict(
                 source_config_dict['bigQuery']
             )
+        )
+
+
+@dataclass(frozen=True)
+class OpenSearchIngestionPipelineConfig:
+    name: str
+    definition:  str
+
+    @staticmethod
+    def from_dict(
+        ingestion_pipeline_config_dict: OpenSearchIngestionPipelineConfigDict
+    ) -> 'OpenSearchIngestionPipelineConfig':
+        return OpenSearchIngestionPipelineConfig(
+            name=ingestion_pipeline_config_dict['name'],
+            definition=ingestion_pipeline_config_dict['definition']
         )
 
 

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Sequence
 
 from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
-    OpenSearchIngestionPipelineConfigDict,
+    OpenSearchIngestPipelineConfigDict,
     OpenSearchTargetConfigDict
 )
 from data_pipeline.utils.pipeline_config import (
@@ -60,20 +60,20 @@ class OpenSearchIngestPipelineConfig:
 
     @staticmethod
     def from_dict(
-        ingestion_pipeline_config_dict: OpenSearchIngestionPipelineConfigDict
+        ingest_pipeline_config_dict: OpenSearchIngestPipelineConfigDict
     ) -> 'OpenSearchIngestPipelineConfig':
         return OpenSearchIngestPipelineConfig(
-            name=ingestion_pipeline_config_dict['name'],
-            definition=ingestion_pipeline_config_dict['definition']
+            name=ingest_pipeline_config_dict['name'],
+            definition=ingest_pipeline_config_dict['definition']
         )
 
     @staticmethod
     def from_dict_list(
-        ingestion_pipeline_config_dict_list: Sequence[OpenSearchIngestionPipelineConfigDict]
+        ingest_pipeline_config_dict_list: Sequence[OpenSearchIngestPipelineConfigDict]
     ) -> Sequence['OpenSearchIngestPipelineConfig']:
         return list(map(
             OpenSearchIngestPipelineConfig.from_dict,
-            ingestion_pipeline_config_dict_list
+            ingest_pipeline_config_dict_list
         ))
 
 
@@ -118,7 +118,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
             update_index_settings=opensearch_target_config_dict.get('updateIndexSettings', False),
             update_mappings=opensearch_target_config_dict.get('updateMappings', False),
             ingest_pipelines=OpenSearchIngestPipelineConfig.from_dict_list(
-                opensearch_target_config_dict.get('ingestionPipelines', [])
+                opensearch_target_config_dict.get('ingestPipelines', [])
             ),
             index_settings=opensearch_target_config_dict.get('indexSettings'),
             verify_certificates=opensearch_target_config_dict.get('verifyCertificates', True),

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, field
 from typing import Optional, Sequence
 
 from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
-    OpenSearchIngestionPipelineConfigDict
+    OpenSearchIngestionPipelineConfigDict,
+    OpenSearchTargetConfigDict
 )
 from data_pipeline.utils.pipeline_config import (
     BigQuerySourceConfig,
@@ -83,7 +84,9 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
     upsert: bool = False
 
     @staticmethod
-    def from_dict(opensearch_target_config_dict: dict) -> 'OpenSearchTargetConfig':
+    def from_dict(
+        opensearch_target_config_dict: OpenSearchTargetConfigDict
+    ) -> 'OpenSearchTargetConfig':
         secrets = get_resolved_parameter_values_from_file_path_env_name(
             opensearch_target_config_dict['secrets']['parametersFromFile']
         )

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config.py
@@ -67,6 +67,15 @@ class OpenSearchIngestionPipelineConfig:
             definition=ingestion_pipeline_config_dict['definition']
         )
 
+    @staticmethod
+    def from_dict_list(
+        ingestion_pipeline_config_dict_list: Sequence[OpenSearchIngestionPipelineConfigDict]
+    ) -> Sequence['OpenSearchIngestionPipelineConfig']:
+        return list(map(
+            OpenSearchIngestionPipelineConfig.from_dict,
+            ingestion_pipeline_config_dict_list
+        ))
+
 
 @dataclass(frozen=True)
 class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
@@ -79,6 +88,7 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
     update_index_settings: bool = False
     update_mappings: bool = False
     index_settings: Optional[dict] = None
+    ingestion_pipelines: Sequence[OpenSearchIngestionPipelineConfig] = field(default_factory=list)
     verify_certificates: bool = True
     operation_mode: str = DEFAULT_OPENSEARCH_OPERATION_MODE
     upsert: bool = False
@@ -107,6 +117,9 @@ class OpenSearchTargetConfig:  # pylint: disable=too-many-instance-attributes
             timeout=opensearch_target_config_dict.get('timeout', DEFAULT_OPENSEARCH_TIMEOUT),
             update_index_settings=opensearch_target_config_dict.get('updateIndexSettings', False),
             update_mappings=opensearch_target_config_dict.get('updateMappings', False),
+            ingestion_pipelines=OpenSearchIngestionPipelineConfig.from_dict_list(
+                opensearch_target_config_dict.get('ingestionPipelines', [])
+            ),
             index_settings=opensearch_target_config_dict.get('indexSettings'),
             verify_certificates=opensearch_target_config_dict.get('verifyCertificates', True),
             operation_mode=operation_mode,

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -6,13 +6,13 @@ from data_pipeline.utils.pipeline_config_typing import (
 )
 
 
+class OpenSearchSecretsConfigDict(TypedDict):
+    parametersFromFile: Sequence[ParameterFromFileConfigDict]
+
+
 class OpenSearchIngestionPipelineConfigDict(TypedDict):
     name: str
     definition: str
-
-
-class OpenSearchSecretsConfigDict(TypedDict):
-    parametersFromFile: Sequence[ParameterFromFileConfigDict]
 
 
 class OpenSearchTargetConfigDict(TypedDict):

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -23,6 +23,7 @@ class OpenSearchTargetConfigDict(TypedDict):
     timeout: NotRequired[float]
     updateIndexSettings: NotRequired[bool]
     updateMappings: NotRequired[bool]
+    ingestionPipelines: NotRequired[Sequence[OpenSearchIngestionPipelineConfigDict]]
     indexSettings: NotRequired[dict]
     verifyCertificates: NotRequired[bool]
     operationMode: NotRequired[str]

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -1,0 +1,6 @@
+from typing_extensions import TypedDict
+
+
+class OpenSearchIngestionPipelineConfigDict(TypedDict):
+    name: str
+    definition: str

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -1,6 +1,29 @@
-from typing_extensions import TypedDict
+from typing import Sequence
+from typing_extensions import NotRequired, TypedDict
+
+from data_pipeline.utils.pipeline_config_typing import (
+    ParameterFromFileConfigDict
+)
 
 
 class OpenSearchIngestionPipelineConfigDict(TypedDict):
     name: str
     definition: str
+
+
+class OpenSearchSecretsConfigDict(TypedDict):
+    parametersFromFile: Sequence[ParameterFromFileConfigDict]
+
+
+class OpenSearchTargetConfigDict(TypedDict):
+    hostname: str
+    port: int
+    secrets: OpenSearchSecretsConfigDict
+    indexName: str
+    timeout: NotRequired[float]
+    updateIndexSettings: NotRequired[bool]
+    updateMappings: NotRequired[bool]
+    indexSettings: NotRequired[dict]
+    verifyCertificates: NotRequired[bool]
+    operationMode: NotRequired[str]
+    upsert: NotRequired[bool]

--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -10,7 +10,7 @@ class OpenSearchSecretsConfigDict(TypedDict):
     parametersFromFile: Sequence[ParameterFromFileConfigDict]
 
 
-class OpenSearchIngestionPipelineConfigDict(TypedDict):
+class OpenSearchIngestPipelineConfigDict(TypedDict):
     name: str
     definition: str
 
@@ -23,7 +23,7 @@ class OpenSearchTargetConfigDict(TypedDict):
     timeout: NotRequired[float]
     updateIndexSettings: NotRequired[bool]
     updateMappings: NotRequired[bool]
-    ingestionPipelines: NotRequired[Sequence[OpenSearchIngestionPipelineConfigDict]]
+    ingestPipelines: NotRequired[Sequence[OpenSearchIngestPipelineConfigDict]]
     indexSettings: NotRequired[dict]
     verifyCertificates: NotRequired[bool]
     operationMode: NotRequired[str]

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -124,7 +124,7 @@ def create_or_update_opensearch_index(
         client.indices.create(index=index_name, body=index_settings)
 
 
-def prepare_opensearch(
+def setup_opensearch(
     client: OpenSearch,
     opensearch_target_config: OpenSearchTargetConfig
 ):
@@ -257,7 +257,7 @@ def create_or_update_index_and_load_documents_into_opensearch(
 ):
     client = get_opensearch_client(config.target.opensearch)
     LOGGER.info('client: %r', client)
-    prepare_opensearch(
+    setup_opensearch(
         client=client,
         opensearch_target_config=config.target.opensearch
     )

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -251,7 +251,7 @@ def get_max_timestamp_from_documents(
     )
 
 
-def create_or_update_index_and_load_documents_into_opensearch(
+def setup_opensearch_and_load_documents_into_opensearch(
     document_iterable: Iterable[dict],
     config: BigQueryToOpenSearchConfig
 ):
@@ -296,7 +296,7 @@ def fetch_documents_from_bigquery_and_load_into_opensearch(
     start_timestamp = load_state_or_default_from_s3_for_config(config.state)
     LOGGER.info('start_timestamp: %r', start_timestamp)
     document_iterable = iter_documents_from_bigquery(config, start_timestamp=start_timestamp)
-    create_or_update_index_and_load_documents_into_opensearch(
+    setup_opensearch_and_load_documents_into_opensearch(
         document_iterable,
         config=config
     )

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -82,7 +82,7 @@ def create_or_update_opensearch_ingest_pipeline(
     client: OpenSearch,
     ingest_pipeline_config: OpenSearchIngestPipelineConfig
 ):
-    LOGGER.info('Creating or updating ingesting pipeline: %r', ingest_pipeline_config.name)
+    LOGGER.info('Creating or updating ingest pipeline: %r', ingest_pipeline_config.name)
     client.ingest.put_pipeline(
         id=ingest_pipeline_config.name,
         body=ingest_pipeline_config.definition

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -10,7 +10,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     BigQueryToOpenSearchConfig,
     BigQueryToOpenSearchFieldNamesForConfig,
     BigQueryToOpenSearchStateConfig,
-    OpenSearchIngestionPipelineConfig,
+    OpenSearchIngestPipelineConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
 )
@@ -80,7 +80,7 @@ def get_opensearch_client(opensearch_target_config: OpenSearchTargetConfig) -> O
 
 def create_or_update_opensearch_ingest_pipeline(
     client: OpenSearch,
-    ingest_pipeline_config: OpenSearchIngestionPipelineConfig
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
 ):
     LOGGER.info('Creating or updating ingesting pipeline: %r', ingest_pipeline_config.name)
     client.ingest.put_pipeline(
@@ -91,7 +91,7 @@ def create_or_update_opensearch_ingest_pipeline(
 
 def create_or_update_opensearch_ingest_pipelines(
     client: OpenSearch,
-    ingest_pipeline_config_list: Sequence[OpenSearchIngestionPipelineConfig]
+    ingest_pipeline_config_list: Sequence[OpenSearchIngestPipelineConfig]
 ):
     LOGGER.debug('ingest_pipeline_config_list: %r', ingest_pipeline_config_list)
     for ingest_pipeline_config in ingest_pipeline_config_list:
@@ -130,7 +130,7 @@ def prepare_opensearch(
 ):
     create_or_update_opensearch_ingest_pipelines(
         client=client,
-        ingest_pipeline_config_list=opensearch_target_config.ingestion_pipelines
+        ingest_pipeline_config_list=opensearch_target_config.ingest_pipelines
     )
     create_or_update_opensearch_index(
         client=client,

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -62,7 +62,7 @@ bigQueryToOpenSearch:
         updateMappings: True
         operationMode: 'update'
         upsert: True
-        ingestionPipelines:
+        ingestPipelines:
           - name: dev_preprints_v2_publication_date_pipeline
             definition: |-
               {

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -62,6 +62,43 @@ bigQueryToOpenSearch:
         updateMappings: True
         operationMode: 'update'
         upsert: True
+        ingestionPipelines:
+          dev_preprints_v2_publication_date_pipeline: |-
+            {
+              "description": "Sets calculated.publication_date from crossref or europepmc",
+              "processors": [
+                {
+                  "remove": {
+                    "field": "calculated.publication_date",
+                    "if": "ctx.calculated?.publication_date != null"
+                  }
+                },
+                {
+                  "set": {
+                    "if": "ctx.calculated?.publication_date == null && ctx.crossref?.publication_date != null",
+                    "field": "calculated.publication_date",
+                    "value": "{{crossref.publication_date}}"
+                  }
+                },
+                {
+                  "set": {
+                    "if": "ctx.calculated?.publication_date == null && ctx.europepmc?.first_publication_date != null",
+                    "field": "calculated.publication_date",
+                    "value": "{{europepmc.first_publication_date}}"
+                  }
+                }
+              ]
+            }
+          dev_preprints_v2_default_pipeline: |-
+            {
+              "processors": [
+                {
+                  "pipeline": {
+                    "name": "dev_preprints_v2_publication_date_pipeline"
+                  }
+                }
+              ]
+            }
         indexSettings:
           # Note: These settings can usually only be applied to a new index.
           #   It is important to set for example the "knn_vector" fields ahead of time.
@@ -71,6 +108,7 @@ bigQueryToOpenSearch:
               # Default values: https://opensearch.org/docs/latest/search-plugins/knn/knn-index/
               knn: True
               "knn.algo_param.ef_search": 512
+              default_pipeline: 'dev_preprints_v2_default_pipeline'
           mappings:
             properties:
                 doi:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -63,42 +63,44 @@ bigQueryToOpenSearch:
         operationMode: 'update'
         upsert: True
         ingestionPipelines:
-          dev_preprints_v2_publication_date_pipeline: |-
-            {
-              "description": "Sets calculated.publication_date from crossref or europepmc",
-              "processors": [
-                {
-                  "remove": {
-                    "field": "calculated.publication_date",
-                    "if": "ctx.calculated?.publication_date != null"
+          - name: dev_preprints_v2_publication_date_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.publication_date from crossref or europepmc",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.publication_date",
+                      "if": "ctx.calculated?.publication_date != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.publication_date == null && ctx.crossref?.publication_date != null",
+                      "field": "calculated.publication_date",
+                      "value": "{{crossref.publication_date}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.publication_date == null && ctx.europepmc?.first_publication_date != null",
+                      "field": "calculated.publication_date",
+                      "value": "{{europepmc.first_publication_date}}"
+                    }
                   }
-                },
-                {
-                  "set": {
-                    "if": "ctx.calculated?.publication_date == null && ctx.crossref?.publication_date != null",
-                    "field": "calculated.publication_date",
-                    "value": "{{crossref.publication_date}}"
+                ]
+              }
+          - name: dev_preprints_v2_default_pipeline
+            definition: |-
+              {
+                "processors": [
+                  {
+                    "pipeline": {
+                      "name": "dev_preprints_v2_publication_date_pipeline"
+                    }
                   }
-                },
-                {
-                  "set": {
-                    "if": "ctx.calculated?.publication_date == null && ctx.europepmc?.first_publication_date != null",
-                    "field": "calculated.publication_date",
-                    "value": "{{europepmc.first_publication_date}}"
-                  }
-                }
-              ]
-            }
-          dev_preprints_v2_default_pipeline: |-
-            {
-              "processors": [
-                {
-                  "pipeline": {
-                    "name": "dev_preprints_v2_publication_date_pipeline"
-                  }
-                }
-              ]
-            }
+                ]
+              }
         indexSettings:
           # Note: These settings can usually only be applied to a new index.
           #   It is important to set for example the "knn_vector" fields ahead of time.

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -7,8 +7,12 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_OPENSEARCH_TIMEOUT,
     BigQueryToOpenSearchConfig,
+    OpenSearchIngestionPipelineConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
+)
+from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
+    OpenSearchIngestionPipelineConfigDict
 )
 from data_pipeline.utils.pipeline_config import BigQuerySourceConfig
 
@@ -49,6 +53,12 @@ BIGQUERY_SOURCE_CONFIG_DICT_1 = {
 
 OPENSEARCH_INDEX_SETTNGS_1 = {
     'settings': {'index': {'some_setting': 'value'}}
+}
+
+
+OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1: OpenSearchIngestionPipelineConfigDict = {
+    'name': 'ingestion_pipeline_1',
+    'definition': 'ingestion_pipeline_definition_1'
 }
 
 
@@ -94,6 +104,19 @@ def _password_file_path(mock_env: dict, tmp_path: Path) -> str:
     file_path.write_text(PASSWORD_1)
     mock_env[OPENSEARCH_PASSWORD_FILE_PATH_ENV_VAR] = str(file_path)
     return str(file_path)
+
+
+class TestOpenSearchIngestionPipelineConfig:
+    def test_should_read_name_and_definition(self):
+        ingestion_pipeline_config = OpenSearchIngestionPipelineConfig.from_dict(
+            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
+        )
+        assert ingestion_pipeline_config.name == (
+            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1['name']
+        )
+        assert ingestion_pipeline_config.definition == (
+            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1['definition']
+        )
 
 
 class TestOpenSearchTargetConfig:

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -12,7 +12,8 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     OpenSearchTargetConfig
 )
 from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
-    OpenSearchIngestionPipelineConfigDict
+    OpenSearchIngestionPipelineConfigDict,
+    OpenSearchTargetConfigDict
 )
 from data_pipeline.utils.pipeline_config import BigQuerySourceConfig
 
@@ -62,7 +63,7 @@ OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1: OpenSearchIngestionPipelineConfigDi
 }
 
 
-OPENSEARCH_TARGET_CONFIG_DICT_1 = {
+OPENSEARCH_TARGET_CONFIG_DICT_1: OpenSearchTargetConfigDict = {
     'hostname': 'hostname1',
     'port': 9200,
     'secrets': {
@@ -202,7 +203,7 @@ class TestOpenSearchTargetConfig:
     @pytest.mark.parametrize('value', [
         OpenSearchOperationModes.INDEX, OpenSearchOperationModes.UPDATE
     ])
-    def test_should_read_operation_mode(self, value: bool):
+    def test_should_read_operation_mode(self, value: str):
         opensearch_target_config = OpenSearchTargetConfig.from_dict({
             **OPENSEARCH_TARGET_CONFIG_DICT_1,
             'operationMode': value

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -12,7 +12,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     OpenSearchTargetConfig
 )
 from data_pipeline.opensearch.bigquery_to_opensearch_config_typing import (
-    OpenSearchIngestionPipelineConfigDict,
+    OpenSearchIngestPipelineConfigDict,
     OpenSearchTargetConfigDict
 )
 from data_pipeline.utils.pipeline_config import BigQuerySourceConfig
@@ -57,9 +57,9 @@ OPENSEARCH_INDEX_SETTNGS_1 = {
 }
 
 
-OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1: OpenSearchIngestionPipelineConfigDict = {
-    'name': 'ingestion_pipeline_1',
-    'definition': 'ingestion_pipeline_definition_1'
+OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1: OpenSearchIngestPipelineConfigDict = {
+    'name': 'ingest_pipeline_1',
+    'definition': 'ingest_pipeline_definition_1'
 }
 
 
@@ -110,13 +110,13 @@ def _password_file_path(mock_env: dict, tmp_path: Path) -> str:
 class TestOpenSearchIngestionPipelineConfig:
     def test_should_read_name_and_definition(self):
         ingestion_pipeline_config = OpenSearchIngestPipelineConfig.from_dict(
-            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1
         )
         assert ingestion_pipeline_config.name == (
-            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1['name']
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1['name']
         )
         assert ingestion_pipeline_config.definition == (
-            OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1['definition']
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1['definition']
         )
 
 
@@ -225,14 +225,14 @@ class TestOpenSearchTargetConfig:
         })
         assert opensearch_target_config.upsert == value
 
-    def test_should_read_ingestion_pipelines(self):
+    def test_should_read_ingest_pipelines(self):
         opensearch_target_config = OpenSearchTargetConfig.from_dict({
             **OPENSEARCH_TARGET_CONFIG_DICT_1,
-            'ingestionPipelines': [OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1]
+            'ingestPipelines': [OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1]
         })
         assert opensearch_target_config.ingest_pipelines == [
             OpenSearchIngestPipelineConfig.from_dict(
-                OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_DICT_1
             )
         ]
 

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -225,6 +225,17 @@ class TestOpenSearchTargetConfig:
         })
         assert opensearch_target_config.upsert == value
 
+    def test_should_read_ingestion_pipelines(self):
+        opensearch_target_config = OpenSearchTargetConfig.from_dict({
+            **OPENSEARCH_TARGET_CONFIG_DICT_1,
+            'ingestionPipelines': [OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1]
+        })
+        assert opensearch_target_config.ingestion_pipelines == [
+            OpenSearchIngestionPipelineConfig.from_dict(
+                OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
+            )
+        ]
+
 
 class TestBigQueryToOpenSearchConfig:
     def test_should_load_empty_list_with_empty_config(self):

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_config_test.py
@@ -7,7 +7,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_OPENSEARCH_TIMEOUT,
     BigQueryToOpenSearchConfig,
-    OpenSearchIngestionPipelineConfig,
+    OpenSearchIngestPipelineConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
 )
@@ -109,7 +109,7 @@ def _password_file_path(mock_env: dict, tmp_path: Path) -> str:
 
 class TestOpenSearchIngestionPipelineConfig:
     def test_should_read_name_and_definition(self):
-        ingestion_pipeline_config = OpenSearchIngestionPipelineConfig.from_dict(
+        ingestion_pipeline_config = OpenSearchIngestPipelineConfig.from_dict(
             OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
         )
         assert ingestion_pipeline_config.name == (
@@ -230,8 +230,8 @@ class TestOpenSearchTargetConfig:
             **OPENSEARCH_TARGET_CONFIG_DICT_1,
             'ingestionPipelines': [OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1]
         })
-        assert opensearch_target_config.ingestion_pipelines == [
-            OpenSearchIngestionPipelineConfig.from_dict(
+        assert opensearch_target_config.ingest_pipelines == [
+            OpenSearchIngestPipelineConfig.from_dict(
                 OPENSEARCH_INGESTION_PIPELINE_CONFIG_DICT_1
             )
         ]

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -678,7 +678,7 @@ class TestLoadDocumentsIntoOpenSearch:
         assert not list(streaming_bulk_result_iterable)
 
 
-class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
+class TestSetupOpenSearchAndLoadDocumentsIntoOpenSearch:
     def test_should_pass_config_to_setup_opensearch_method(
         self,
         get_opensearch_client_mock: MagicMock,

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -31,7 +31,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_pipeline import (
     iter_documents_from_bigquery,
     iter_opensearch_bulk_action_for_documents,
     load_documents_into_opensearch,
-    prepare_opensearch
+    setup_opensearch
 )
 
 
@@ -180,9 +180,9 @@ def _create_or_update_opensearch_index_mock() -> Iterator[MagicMock]:
         yield mock
 
 
-@pytest.fixture(name='prepare_opensearch_mock')
-def _prepare_opensearch_mock() -> Iterator[MagicMock]:
-    with patch.object(test_module, 'prepare_opensearch') as mock:
+@pytest.fixture(name='setup_opensearch_mock')
+def _setup_opensearch_mock() -> Iterator[MagicMock]:
+    with patch.object(test_module, 'setup_opensearch') as mock:
         yield mock
 
 
@@ -504,13 +504,13 @@ class TestCreateOrUpdateOpenSearchIndex:
         )
 
 
-class TestPrepareOpenSearch:
+class TestSetupOpenSearch:
     def test_should_pass_config_to_create_or_update_opensearch_ingestion_pipeline_method(
         self,
         opensearch_client_mock: MagicMock,
         create_or_update_opensearch_ingest_pipeline_mock: MagicMock
     ):
-        prepare_opensearch(
+        setup_opensearch(
             client=opensearch_client_mock,
             opensearch_target_config=dataclasses.replace(
                 OPENSEARCH_TARGET_CONFIG_1,
@@ -527,7 +527,7 @@ class TestPrepareOpenSearch:
         opensearch_client_mock: MagicMock,
         create_or_update_opensearch_index_mock: MagicMock
     ):
-        prepare_opensearch(
+        setup_opensearch(
             client=opensearch_client_mock,
             opensearch_target_config=OPENSEARCH_TARGET_CONFIG_1
         )
@@ -679,16 +679,16 @@ class TestLoadDocumentsIntoOpenSearch:
 
 
 class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
-    def test_should_pass_config_to_prepare_opensearch_method(
+    def test_should_pass_config_to_setup_opensearch_method(
         self,
         get_opensearch_client_mock: MagicMock,
-        prepare_opensearch_mock: MagicMock
+        setup_opensearch_mock: MagicMock
     ):
         create_or_update_index_and_load_documents_into_opensearch(
             [DOCUMENT_1],
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )
-        prepare_opensearch_mock.assert_called_with(
+        setup_opensearch_mock.assert_called_with(
             client=get_opensearch_client_mock.return_value,
             opensearch_target_config=OPENSEARCH_TARGET_CONFIG_1
         )

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -15,7 +15,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     BigQueryToOpenSearchSourceConfig,
     BigQueryToOpenSearchStateConfig,
     BigQueryToOpenSearchTargetConfig,
-    OpenSearchIngestionPipelineConfig,
+    OpenSearchIngestPipelineConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
 )
@@ -47,9 +47,9 @@ OPENSEARCH_INDEX_SETTNGS_WITH_MAPPINGS_1 = {
 OPENSEARCH_INDEX_SETTNGS_1 = OPENSEARCH_INDEX_SETTNGS_WITHOUT_MAPPINGS_1
 
 
-OPENSEARCH_INGEST_PIPELINE_CONFIG_1 = OpenSearchIngestionPipelineConfig(
-    name='ingestion_pipeline_1',
-    definition='ingestion_pipeline_definition_1'
+OPENSEARCH_INGEST_PIPELINE_CONFIG_1 = OpenSearchIngestPipelineConfig(
+    name='ingest_pipeline_1',
+    definition='ingest_pipeline_definition_1'
 )
 
 
@@ -514,7 +514,7 @@ class TestPrepareOpenSearch:
             client=opensearch_client_mock,
             opensearch_target_config=dataclasses.replace(
                 OPENSEARCH_TARGET_CONFIG_1,
-                ingestion_pipelines=[OPENSEARCH_INGEST_PIPELINE_CONFIG_1]
+                ingest_pipelines=[OPENSEARCH_INGEST_PIPELINE_CONFIG_1]
             )
         )
         create_or_update_opensearch_ingest_pipeline_mock.assert_called_with(

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -21,7 +21,7 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
 )
 import data_pipeline.opensearch.bigquery_to_opensearch_pipeline as test_module
 from data_pipeline.opensearch.bigquery_to_opensearch_pipeline import (
-    create_or_update_index_and_load_documents_into_opensearch,
+    setup_opensearch_and_load_documents_into_opensearch,
     create_or_update_opensearch_index,
     create_or_update_opensearch_ingest_pipeline,
     fetch_documents_from_bigquery_and_load_into_opensearch,
@@ -199,11 +199,11 @@ def _load_documents_into_opensearch_mock() -> Iterator[MagicMock]:
         yield mock
 
 
-@pytest.fixture(name='create_or_update_index_and_load_documents_into_opensearch_mock')
-def _create_or_update_index_and_load_documents_into_opensearch_mock() -> Iterator[MagicMock]:
+@pytest.fixture(name='setup_opensearch_and_load_documents_into_opensearch_mock')
+def _setup_opensearch_and_load_documents_into_opensearch_mock() -> Iterator[MagicMock]:
     with patch.object(
         test_module,
-        'create_or_update_index_and_load_documents_into_opensearch'
+        'setup_opensearch_and_load_documents_into_opensearch'
     ) as mock:
         yield mock
 
@@ -684,7 +684,7 @@ class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
         get_opensearch_client_mock: MagicMock,
         setup_opensearch_mock: MagicMock
     ):
-        create_or_update_index_and_load_documents_into_opensearch(
+        setup_opensearch_and_load_documents_into_opensearch(
             [DOCUMENT_1],
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )
@@ -698,7 +698,7 @@ class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
         get_opensearch_client_mock: MagicMock,
         load_documents_into_opensearch_mock: MagicMock
     ):
-        create_or_update_index_and_load_documents_into_opensearch(
+        setup_opensearch_and_load_documents_into_opensearch(
             [DOCUMENT_1],
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )
@@ -714,7 +714,7 @@ class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
         self,
         load_documents_into_opensearch_mock: MagicMock
     ):
-        create_or_update_index_and_load_documents_into_opensearch(
+        setup_opensearch_and_load_documents_into_opensearch(
             [DOCUMENT_1, DOCUMENT_2, DOCUMENT_3],
             config=dataclasses.replace(
                 BIGQUERY_TO_OPENSEARCH_CONFIG_1,
@@ -742,7 +742,7 @@ class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
         self,
         save_state_to_s3_for_config_mock: MagicMock
     ):
-        create_or_update_index_and_load_documents_into_opensearch(
+        setup_opensearch_and_load_documents_into_opensearch(
             [DOCUMENT_1],
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )
@@ -755,7 +755,7 @@ class TestCreateOrUpdateIndexAndLoadDocumentsIntoOpenSearch:
         self,
         get_opensearch_client_mock: MagicMock
     ):
-        create_or_update_index_and_load_documents_into_opensearch(
+        setup_opensearch_and_load_documents_into_opensearch(
             [DOCUMENT_1],
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )
@@ -766,7 +766,7 @@ class TestFetchDocumentsFromBigQueryAndLoadIntoOpenSearch:
     def test_should_fetch_documents_from_bigquery_and_pass_to_opensearch(
         self,
         iter_documents_from_bigquery_mock: MagicMock,
-        create_or_update_index_and_load_documents_into_opensearch_mock: MagicMock,
+        setup_opensearch_and_load_documents_into_opensearch_mock: MagicMock,
         load_state_or_default_from_s3_for_config_mock: MagicMock
     ):
         fetch_documents_from_bigquery_and_load_into_opensearch(
@@ -776,7 +776,7 @@ class TestFetchDocumentsFromBigQueryAndLoadIntoOpenSearch:
             BIGQUERY_TO_OPENSEARCH_CONFIG_1,
             start_timestamp=load_state_or_default_from_s3_for_config_mock.return_value
         )
-        create_or_update_index_and_load_documents_into_opensearch_mock.assert_called_with(
+        setup_opensearch_and_load_documents_into_opensearch_mock.assert_called_with(
             iter_documents_from_bigquery_mock.return_value,
             config=BIGQUERY_TO_OPENSEARCH_CONFIG_1
         )


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/963

This adds support for [OpenSearch Ingest pipelines](https://opensearch.org/docs/latest/ingest-pipelines/).
That way we can pre-calculate fields at ingest time.