### PR TITLE
OpenSearch ingest pipeline tests

### DIFF
--- a/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_config_typing.py
@@ -10,9 +10,16 @@ class OpenSearchSecretsConfigDict(TypedDict):
     parametersFromFile: Sequence[ParameterFromFileConfigDict]
 
 
+class OpenSearchIngestPipelineTestConfigDict(TypedDict):
+    description: str
+    inputDocument: str
+    expectedDocument: str
+
+
 class OpenSearchIngestPipelineConfigDict(TypedDict):
     name: str
     definition: str
+    tests: NotRequired[Sequence[OpenSearchIngestPipelineTestConfigDict]]
 
 
 class OpenSearchTargetConfigDict(TypedDict):

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -128,7 +128,11 @@ def assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
         )
     )
     if not failed_opensearch_ingest_pipeline_test_and_actual_document:
-        LOGGER.info('Ingest pipeline tests passed: %r', ingest_pipeline_config.name)
+        passed_descriptions = [
+            ingest_pipeline_test_config.description
+            for ingest_pipeline_test_config in ingest_pipeline_config.tests
+        ]
+        LOGGER.info('Ingest pipeline tests passed: %r', passed_descriptions)
         return
     failed_descriptions = []
     for opensearch_ingest_pipeline_test_config, actual_document in (

--- a/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
+++ b/data_pipeline/opensearch/bigquery_to_opensearch_pipeline.py
@@ -1,8 +1,7 @@
 import dataclasses
 from datetime import datetime
-import json
 import logging
-from typing import Any, Iterable, Sequence, Tuple
+from typing import Any, Iterable, Sequence
 
 from opensearchpy import OpenSearch
 import opensearchpy
@@ -11,11 +10,10 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     BigQueryToOpenSearchConfig,
     BigQueryToOpenSearchFieldNamesForConfig,
     BigQueryToOpenSearchStateConfig,
-    OpenSearchIngestPipelineConfig,
-    OpenSearchIngestPipelineTestConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
 )
+from data_pipeline.opensearch.ingest_pipeline import create_or_update_opensearch_ingest_pipelines
 from data_pipeline.utils.collections import iter_batch_iterable
 from data_pipeline.utils.data_store.s3_data_service import (
     download_s3_object_as_string_or_file_not_found_error,
@@ -78,121 +76,6 @@ def get_opensearch_client(opensearch_target_config: OpenSearchTargetConfig) -> O
         verify_certs=opensearch_target_config.verify_certificates,
         ssl_show_warn=opensearch_target_config.verify_certificates
     )
-
-
-def get_opensearch_ingest_pipeline_tests_body(
-    ingest_pipeline_config: OpenSearchIngestPipelineConfig
-) -> dict:
-    return {
-        'pipeline': json.loads(ingest_pipeline_config.definition),
-        'docs': [
-            {
-                '_source': ingest_pipeline_test_config.input_document
-            }
-            for ingest_pipeline_test_config in ingest_pipeline_config.tests
-        ]
-    }
-
-
-def get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response(
-    simulate_response: dict
-) -> Sequence[dict]:
-    LOGGER.debug('simulate_response: %r', simulate_response)
-    return [
-        doc['doc']['_source']
-        for doc in simulate_response['docs']
-    ]
-
-
-def iter_failed_opensearch_ingest_pipeline_test_and_actual_document(
-    actual_documents: Sequence[dict],
-    ingest_pipeline_config: OpenSearchIngestPipelineConfig
-) -> Iterable[Tuple[OpenSearchIngestPipelineTestConfig, dict]]:
-    assert len(actual_documents) == len(ingest_pipeline_config.tests)
-    for ingest_pipeline_test_config, actual_document in zip(
-        ingest_pipeline_config.tests,
-        actual_documents
-    ):
-        if actual_document != ingest_pipeline_test_config.expected_document:
-            yield ingest_pipeline_test_config, actual_document
-
-
-def assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
-    actual_documents: Sequence[dict],
-    ingest_pipeline_config: OpenSearchIngestPipelineConfig
-):
-    failed_opensearch_ingest_pipeline_test_and_actual_document = list(
-        iter_failed_opensearch_ingest_pipeline_test_and_actual_document(
-            actual_documents=actual_documents,
-            ingest_pipeline_config=ingest_pipeline_config
-        )
-    )
-    if not failed_opensearch_ingest_pipeline_test_and_actual_document:
-        passed_descriptions = [
-            ingest_pipeline_test_config.description
-            for ingest_pipeline_test_config in ingest_pipeline_config.tests
-        ]
-        LOGGER.info('Ingest pipeline tests passed: %r', passed_descriptions)
-        return
-    failed_descriptions = []
-    for opensearch_ingest_pipeline_test_config, actual_document in (
-        failed_opensearch_ingest_pipeline_test_and_actual_document
-    ):
-        LOGGER.warning(
-            'Ingest pipeline test failed: description=%r, actual=%r, expected=%r',
-            opensearch_ingest_pipeline_test_config.description,
-            actual_document,
-            opensearch_ingest_pipeline_test_config.expected_document
-        )
-        failed_descriptions.append(opensearch_ingest_pipeline_test_config.description)
-    raise AssertionError(f'Ingest pipeline test failures: {failed_descriptions}')
-
-
-def run_opensearch_ingest_pipeline_tests(
-    client: OpenSearch,
-    ingest_pipeline_config: OpenSearchIngestPipelineConfig
-):
-    LOGGER.info('Testing ingest pipeline: %r', ingest_pipeline_config.name)
-    simulate_response = client.ingest.simulate(
-        body=get_opensearch_ingest_pipeline_tests_body(
-            ingest_pipeline_config
-        )
-    )
-    actual_documents = get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response(
-        simulate_response
-    )
-    assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
-        actual_documents=actual_documents,
-        ingest_pipeline_config=ingest_pipeline_config
-    )
-
-
-def create_or_update_opensearch_ingest_pipeline(
-    client: OpenSearch,
-    ingest_pipeline_config: OpenSearchIngestPipelineConfig
-):
-    if ingest_pipeline_config.tests:
-        run_opensearch_ingest_pipeline_tests(
-            client=client,
-            ingest_pipeline_config=ingest_pipeline_config
-        )
-    LOGGER.info('Creating or updating ingest pipeline: %r', ingest_pipeline_config.name)
-    client.ingest.put_pipeline(
-        id=ingest_pipeline_config.name,
-        body=ingest_pipeline_config.definition
-    )
-
-
-def create_or_update_opensearch_ingest_pipelines(
-    client: OpenSearch,
-    ingest_pipeline_config_list: Sequence[OpenSearchIngestPipelineConfig]
-):
-    LOGGER.debug('ingest_pipeline_config_list: %r', ingest_pipeline_config_list)
-    for ingest_pipeline_config in ingest_pipeline_config_list:
-        create_or_update_opensearch_ingest_pipeline(
-            client=client,
-            ingest_pipeline_config=ingest_pipeline_config
-        )
 
 
 def create_or_update_opensearch_index(

--- a/data_pipeline/opensearch/ingest_pipeline.py
+++ b/data_pipeline/opensearch/ingest_pipeline.py
@@ -1,0 +1,128 @@
+import json
+import logging
+from typing import Iterable, Sequence, Tuple
+
+from opensearchpy import OpenSearch
+
+from data_pipeline.opensearch.bigquery_to_opensearch_config import (
+    OpenSearchIngestPipelineConfig,
+    OpenSearchIngestPipelineTestConfig
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_opensearch_ingest_pipeline_tests_body(
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
+) -> dict:
+    return {
+        'pipeline': json.loads(ingest_pipeline_config.definition),
+        'docs': [
+            {
+                '_source': ingest_pipeline_test_config.input_document
+            }
+            for ingest_pipeline_test_config in ingest_pipeline_config.tests
+        ]
+    }
+
+
+def get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response(
+    simulate_response: dict
+) -> Sequence[dict]:
+    LOGGER.debug('simulate_response: %r', simulate_response)
+    return [
+        doc['doc']['_source']
+        for doc in simulate_response['docs']
+    ]
+
+
+def iter_failed_opensearch_ingest_pipeline_test_and_actual_document(
+    actual_documents: Sequence[dict],
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
+) -> Iterable[Tuple[OpenSearchIngestPipelineTestConfig, dict]]:
+    assert len(actual_documents) == len(ingest_pipeline_config.tests)
+    for ingest_pipeline_test_config, actual_document in zip(
+        ingest_pipeline_config.tests,
+        actual_documents
+    ):
+        if actual_document != ingest_pipeline_test_config.expected_document:
+            yield ingest_pipeline_test_config, actual_document
+
+
+def assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+    actual_documents: Sequence[dict],
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
+):
+    failed_opensearch_ingest_pipeline_test_and_actual_document = list(
+        iter_failed_opensearch_ingest_pipeline_test_and_actual_document(
+            actual_documents=actual_documents,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+    )
+    if not failed_opensearch_ingest_pipeline_test_and_actual_document:
+        passed_descriptions = [
+            ingest_pipeline_test_config.description
+            for ingest_pipeline_test_config in ingest_pipeline_config.tests
+        ]
+        LOGGER.info('Ingest pipeline tests passed: %r', passed_descriptions)
+        return
+    failed_descriptions = []
+    for opensearch_ingest_pipeline_test_config, actual_document in (
+        failed_opensearch_ingest_pipeline_test_and_actual_document
+    ):
+        LOGGER.warning(
+            'Ingest pipeline test failed: description=%r, actual=%r, expected=%r',
+            opensearch_ingest_pipeline_test_config.description,
+            actual_document,
+            opensearch_ingest_pipeline_test_config.expected_document
+        )
+        failed_descriptions.append(opensearch_ingest_pipeline_test_config.description)
+    raise AssertionError(f'Ingest pipeline test failures: {failed_descriptions}')
+
+
+def run_opensearch_ingest_pipeline_tests(
+    client: OpenSearch,
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
+):
+    LOGGER.info('Testing ingest pipeline: %r', ingest_pipeline_config.name)
+    simulate_response = client.ingest.simulate(
+        body=get_opensearch_ingest_pipeline_tests_body(
+            ingest_pipeline_config
+        )
+    )
+    actual_documents = get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response(
+        simulate_response
+    )
+    assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+        actual_documents=actual_documents,
+        ingest_pipeline_config=ingest_pipeline_config
+    )
+
+
+def create_or_update_opensearch_ingest_pipeline(
+    client: OpenSearch,
+    ingest_pipeline_config: OpenSearchIngestPipelineConfig
+):
+    if ingest_pipeline_config.tests:
+        run_opensearch_ingest_pipeline_tests(
+            client=client,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+    LOGGER.info('Creating or updating ingest pipeline: %r', ingest_pipeline_config.name)
+    client.ingest.put_pipeline(
+        id=ingest_pipeline_config.name,
+        body=ingest_pipeline_config.definition
+    )
+
+
+def create_or_update_opensearch_ingest_pipelines(
+    client: OpenSearch,
+    ingest_pipeline_config_list: Sequence[OpenSearchIngestPipelineConfig]
+):
+    LOGGER.debug('ingest_pipeline_config_list: %r', ingest_pipeline_config_list)
+    for ingest_pipeline_config in ingest_pipeline_config_list:
+        create_or_update_opensearch_ingest_pipeline(
+            client=client,
+            ingest_pipeline_config=ingest_pipeline_config
+        )

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -63,6 +63,32 @@ bigQueryToOpenSearch:
         operationMode: 'update'
         upsert: True
         ingestPipelines:
+          - name: dev_preprints_v2_doi_prefix_pipeline
+            definition: |-
+              {
+                "description": "Extracts doi_prefix from doi",
+                "processors": [
+                  {
+                    "grok": {
+                      "field": "doi",
+                      "patterns": ["^(?<calculated.doi_prefix>[^/]+)/.*$"]
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should extract doi_prefix from doi"
+                inputDocument: |-
+                  {
+                    "doi": "10.1234/doi_1"
+                  }
+                expectedDocument: |-
+                  {
+                    "doi": "10.1234/doi_1",
+                    "calculated": {
+                      "doi_prefix": "10.1234"
+                    }
+                  }
           - name: dev_preprints_v2_publication_date_pipeline
             definition: |-
               {
@@ -373,6 +399,11 @@ bigQueryToOpenSearch:
                 "processors": [
                   {
                     "pipeline": {
+                      "name": "dev_preprints_v2_doi_prefix_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
                       "name": "dev_preprints_v2_publication_date_pipeline"
                     }
                   },
@@ -402,6 +433,10 @@ bigQueryToOpenSearch:
             properties:
                 doi:
                   type: "text"
+                calculated:
+                  properties:
+                    doi_prefix:
+                      type: "keyword"
                 s2:
                   properties:
                     author_list:

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -91,7 +91,7 @@ bigQueryToOpenSearch:
                 ]
               }
             tests:
-              - description: "Remove existing calculated field"
+              - description: "Should remove existing calculated field"
                 inputDocument: |-
                   {
                     "calculated": {
@@ -103,7 +103,7 @@ bigQueryToOpenSearch:
                     "calculated": {
                     }
                   }
-              - description: "Use Crossref if available"
+              - description: "Should use Crossref if available"
                 inputDocument: |-
                   {
                     "crossref": {

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -157,6 +157,119 @@ bigQueryToOpenSearch:
                       "publication_date": "2001-01-01"
                     }
                   }
+          - name: dev_preprints_v2_title_with_markup_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.title_with_markup from crossref or europepmc or s2",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.title_with_markup",
+                      "if": "ctx.calculated?.title_with_markup != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.crossref?.title_with_markup != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{crossref.title_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.europepmc?.title_with_markup != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{europepmc.title_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.title_with_markup == null && ctx.s2?.title != null",
+                      "field": "calculated.title_with_markup",
+                      "value": "{{s2.title}}"
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "title_with_markup": "Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "calculated": {
+                    }
+                  }
+              - description: "Should prefer title from Crossref over EuropePM and S2"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "title_with_markup": "Crossref Title 1"
+                    },
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "title_with_markup": "Crossref Title 1"
+                    },
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "Crossref Title 1"
+                    }
+                  }
+              - description: "Should prefer title from EuropePMC over S2"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    },
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "EuropePMC Title 1"
+                    }
+                  }
+              - description: "Should fallback to title from s2"
+                inputDocument: |-
+                  {
+                    "s2": {
+                      "title": "S2 Title 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "s2": {
+                      "title": "S2 Title 1"
+                    },
+                    "calculated": {
+                      "title_with_markup": "S2 Title 1"
+                    }
+                  }
           - name: dev_preprints_v2_default_pipeline
             definition: |-
               {
@@ -164,6 +277,11 @@ bigQueryToOpenSearch:
                   {
                     "pipeline": {
                       "name": "dev_preprints_v2_publication_date_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
+                      "name": "dev_preprints_v2_title_with_markup_pipeline"
                     }
                   }
                 ]

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -90,6 +90,33 @@ bigQueryToOpenSearch:
                   }
                 ]
               }
+            tests:
+              - description: "Remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                  }
+              - description: "Use Crossref if available"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-02-03"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
           - name: dev_preprints_v2_default_pipeline
             definition: |-
               {

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -100,6 +100,8 @@ bigQueryToOpenSearch:
                   }
                 expectedDocument: |-
                   {
+                    "calculated": {
+                    }
                   }
               - description: "Use Crossref if available"
                 inputDocument: |-

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -270,6 +270,119 @@ bigQueryToOpenSearch:
                       "title_with_markup": "S2 Title 1"
                     }
                   }
+          - name: dev_preprints_v2_abstract_with_markup_pipeline
+            definition: |-
+              {
+                "description": "Sets calculated.abstract_with_markup from crossref or europepmc or s2",
+                "processors": [
+                  {
+                    "remove": {
+                      "field": "calculated.abstract_with_markup",
+                      "if": "ctx.calculated?.abstract_with_markup != null"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.crossref?.abstract_with_markup != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{crossref.abstract_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.europepmc?.abstract_with_markup != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{europepmc.abstract_with_markup}}"
+                    }
+                  },
+                  {
+                    "set": {
+                      "if": "ctx.calculated?.abstract_with_markup == null && ctx.s2?.abstract != null",
+                      "field": "calculated.abstract_with_markup",
+                      "value": "{{s2.abstract}}"
+                    }
+                  }
+                ]
+              }
+            tests:
+              - description: "Should remove existing calculated field"
+                inputDocument: |-
+                  {
+                    "calculated": {
+                      "abstract_with_markup": "Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "calculated": {
+                    }
+                  }
+              - description: "Should prefer abstract from Crossref over EuropePMC and S2"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    },
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    },
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "Crossref Abstract 1"
+                    }
+                  }
+              - description: "Should prefer abstract from EuropePMC over S2"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    },
+                    "s2": {
+                      "title": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "EuropePMC Abstract 1"
+                    }
+                  }
+              - description: "Should fallback to abstract from S2"
+                inputDocument: |-
+                  {
+                    "s2": {
+                      "abstract": "S2 Abstract 1"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "s2": {
+                      "abstract": "S2 Abstract 1"
+                    },
+                    "calculated": {
+                      "abstract_with_markup": "S2 Abstract 1"
+                    }
+                  }
           - name: dev_preprints_v2_default_pipeline
             definition: |-
               {
@@ -282,6 +395,11 @@ bigQueryToOpenSearch:
                   {
                     "pipeline": {
                       "name": "dev_preprints_v2_title_with_markup_pipeline"
+                    }
+                  },
+                  {
+                    "pipeline": {
+                      "name": "dev_preprints_v2_abstract_with_markup_pipeline"
                     }
                   }
                 ]

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -103,7 +103,7 @@ bigQueryToOpenSearch:
                     "calculated": {
                     }
                   }
-              - description: "Should use Crossref if available"
+              - description: "Should use crossref.publication_date if available"
                 inputDocument: |-
                   {
                     "crossref": {
@@ -117,6 +117,44 @@ bigQueryToOpenSearch:
                     },
                     "calculated": {
                       "publication_date": "2001-02-03"
+                    }
+                  }
+              - description: "Should use europepmc.first_publication_date if available"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-02-03"
+                    }
+                  }
+              - description: "Should prefer crossref publication date over europepmc"
+                inputDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-01-01"
+                    },
+                    "europepmc": {
+                      "first_publication_date": "2001-01-02"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "crossref": {
+                      "publication_date": "2001-01-01"
+                    },
+                    "europepmc": {
+                      "first_publication_date": "2001-01-02"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-01-01"
                     }
                   }
           - name: dev_preprints_v2_default_pipeline

--- a/sample_data_config/opensearch/bigquery-to-opensearch.yaml
+++ b/sample_data_config/opensearch/bigquery-to-opensearch.yaml
@@ -103,39 +103,7 @@ bigQueryToOpenSearch:
                     "calculated": {
                     }
                   }
-              - description: "Should use crossref.publication_date if available"
-                inputDocument: |-
-                  {
-                    "crossref": {
-                      "publication_date": "2001-02-03"
-                    }
-                  }
-                expectedDocument: |-
-                  {
-                    "crossref": {
-                      "publication_date": "2001-02-03"
-                    },
-                    "calculated": {
-                      "publication_date": "2001-02-03"
-                    }
-                  }
-              - description: "Should use europepmc.first_publication_date if available"
-                inputDocument: |-
-                  {
-                    "europepmc": {
-                      "first_publication_date": "2001-02-03"
-                    }
-                  }
-                expectedDocument: |-
-                  {
-                    "europepmc": {
-                      "first_publication_date": "2001-02-03"
-                    },
-                    "calculated": {
-                      "publication_date": "2001-02-03"
-                    }
-                  }
-              - description: "Should prefer crossref publication date over europepmc"
+              - description: "Should prefer publication date from Crossref over EuropePMC"
                 inputDocument: |-
                   {
                     "crossref": {
@@ -155,6 +123,22 @@ bigQueryToOpenSearch:
                     },
                     "calculated": {
                       "publication_date": "2001-01-01"
+                    }
+                  }
+              - description: "Should fallback to publication date from EuropePMC"
+                inputDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    }
+                  }
+                expectedDocument: |-
+                  {
+                    "europepmc": {
+                      "first_publication_date": "2001-02-03"
+                    },
+                    "calculated": {
+                      "publication_date": "2001-02-03"
                     }
                   }
           - name: dev_preprints_v2_title_with_markup_pipeline

--- a/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
+++ b/tests/unit_test/opensearch/bigquery_to_opensearch_pipeline_test.py
@@ -1,5 +1,6 @@
 import dataclasses
 from datetime import datetime
+import json
 from typing import Iterator
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -16,11 +17,16 @@ from data_pipeline.opensearch.bigquery_to_opensearch_config import (
     BigQueryToOpenSearchStateConfig,
     BigQueryToOpenSearchTargetConfig,
     OpenSearchIngestPipelineConfig,
+    OpenSearchIngestPipelineTestConfig,
     OpenSearchOperationModes,
     OpenSearchTargetConfig
 )
 import data_pipeline.opensearch.bigquery_to_opensearch_pipeline as test_module
 from data_pipeline.opensearch.bigquery_to_opensearch_pipeline import (
+    assert_opensearch_ingest_pipeline_test_actual_documents_match_expected,
+    get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response,
+    get_opensearch_ingest_pipeline_tests_body,
+    run_opensearch_ingest_pipeline_tests,
     setup_opensearch_and_load_documents_into_opensearch,
     create_or_update_opensearch_index,
     create_or_update_opensearch_ingest_pipeline,
@@ -47,9 +53,16 @@ OPENSEARCH_INDEX_SETTNGS_WITH_MAPPINGS_1 = {
 OPENSEARCH_INDEX_SETTNGS_1 = OPENSEARCH_INDEX_SETTNGS_WITHOUT_MAPPINGS_1
 
 
+OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1 = OpenSearchIngestPipelineTestConfig(
+    description='Ingest pipeline test 1',
+    input_document={'name': 'input document 1'},
+    expected_document={'name': 'expected document 1'}
+)
+
+
 OPENSEARCH_INGEST_PIPELINE_CONFIG_1 = OpenSearchIngestPipelineConfig(
     name='ingest_pipeline_1',
-    definition='ingest_pipeline_definition_1'
+    definition=json.dumps({'description': 'ingest_pipeline_definition_1'})
 )
 
 
@@ -165,6 +178,22 @@ def _iter_documents_from_bigquery_mock() -> Iterator[MagicMock]:
 def _get_opensearch_client_mock(opensearch_client_mock: MagicMock) -> Iterator[MagicMock]:
     with patch.object(test_module, 'get_opensearch_client') as mock:
         mock.return_value = opensearch_client_mock
+        yield mock
+
+
+@pytest.fixture(name='assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock')
+def _assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock(
+) -> Iterator[MagicMock]:
+    with patch.object(
+        test_module,
+        'assert_opensearch_ingest_pipeline_test_actual_documents_match_expected'
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture(name='run_opensearch_ingest_pipeline_tests_mock')
+def _run_opensearch_ingest_pipeline_tests_mock() -> Iterator[MagicMock]:
+    with patch.object(test_module, 'run_opensearch_ingest_pipeline_tests') as mock:
         yield mock
 
 
@@ -378,6 +407,99 @@ class TestGetOpenSearchClient:
         assert client == opensearch_class_mock.return_value
 
 
+class TestGetOpenSearchIngestPipelineTestsBody:
+    def test_should_parse_pipeline_definition_as_json(self):
+        body = get_opensearch_ingest_pipeline_tests_body(
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+        assert body['pipeline'] == json.loads(OPENSEARCH_INGEST_PIPELINE_CONFIG_1.definition)
+
+    def test_should_include_input_documents_as_source(self):
+        body = get_opensearch_ingest_pipeline_tests_body(
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+        assert len(body['docs']) == 1
+        assert body['docs'][0]['_source'] == (
+            OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.input_document
+        )
+
+
+class TestGetOpenSearchIngestPipelineTestActualDocumentsFromSimulateResponse:
+    def test_should_extract_actual_documents_from_source(self):
+        actual_documents = (
+            get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response({
+                'docs': [{
+                    'doc': {
+                        '_source': OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document
+                    }
+                }]
+            })
+        )
+        assert actual_documents == [OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document]
+
+
+class TestAssertOpenSearchIngestPipelineTestActualDocumentsMatchExpected:
+    def test_should_pass_if_actual_documents_match_expected_documents(self):
+        assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+            actual_documents=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document],
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+
+    def test_should_raise_assertion_error_for_not_matching_documents(self):
+        with pytest.raises(AssertionError):
+            assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+                actual_documents=[{'name': 'not matching actual document'}],
+                ingest_pipeline_config=dataclasses.replace(
+                    OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                    tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+                )
+            )
+
+
+class TestRunOpenSearchIngestPipelineTests:
+    def test_should_simulate_and_assert_documents_match(
+        self,
+        opensearch_client_mock: MagicMock,
+        assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock: MagicMock
+    ):
+        ingest_pipeline_config = dataclasses.replace(
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+            tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+        )
+        opensearch_client_mock.ingest.simulate.return_value = {
+            'docs': [{
+                'doc': {
+                    '_source': {'name': 'actual document 1'}
+                }
+            }]
+        }
+        run_opensearch_ingest_pipeline_tests(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+        opensearch_client_mock.ingest.simulate.assert_called_with(
+            body=get_opensearch_ingest_pipeline_tests_body(
+                ingest_pipeline_config
+            )
+        )
+        (
+            assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock
+            .assert_called_with(
+                actual_documents=[{'name': 'actual document 1'}],
+                ingest_pipeline_config=ingest_pipeline_config
+            )
+        )
+
+
 class TestCreateOrUpdateOpenSearchIngestPipeline:
     def test_should_put_ingest_pipeline(
         self,
@@ -390,6 +512,24 @@ class TestCreateOrUpdateOpenSearchIngestPipeline:
         opensearch_client_mock.ingest.put_pipeline.assert_called_with(
             id=OPENSEARCH_INGEST_PIPELINE_CONFIG_1.name,
             body=OPENSEARCH_INGEST_PIPELINE_CONFIG_1.definition
+        )
+
+    def test_should_run_ingest_pipeline_tests_if_defined(
+        self,
+        opensearch_client_mock: MagicMock,
+        run_opensearch_ingest_pipeline_tests_mock: MagicMock
+    ):
+        ingest_pipeline_config = dataclasses.replace(
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+            tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+        )
+        create_or_update_opensearch_ingest_pipeline(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+        run_opensearch_ingest_pipeline_tests_mock.assert_called_with(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
         )
 
 

--- a/tests/unit_test/opensearch/ingest_pipeline_test.py
+++ b/tests/unit_test/opensearch/ingest_pipeline_test.py
@@ -1,0 +1,166 @@
+import dataclasses
+import json
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import data_pipeline.opensearch.ingest_pipeline as test_module
+from data_pipeline.opensearch.ingest_pipeline import (
+    assert_opensearch_ingest_pipeline_test_actual_documents_match_expected,
+    create_or_update_opensearch_ingest_pipeline,
+    get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response,
+    get_opensearch_ingest_pipeline_tests_body,
+    run_opensearch_ingest_pipeline_tests
+)
+from tests.unit_test.opensearch.bigquery_to_opensearch_pipeline_test import (
+    OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+    OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1
+)
+
+
+@pytest.fixture(name='opensearch_client_mock')
+def _opensearch_client_mock() -> MagicMock:
+    return MagicMock(name='opensearch_client_mock')
+
+
+@pytest.fixture(name='assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock')
+def _assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock(
+) -> Iterator[MagicMock]:
+    with patch.object(
+        test_module,
+        'assert_opensearch_ingest_pipeline_test_actual_documents_match_expected'
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture(name='run_opensearch_ingest_pipeline_tests_mock')
+def _run_opensearch_ingest_pipeline_tests_mock() -> Iterator[MagicMock]:
+    with patch.object(test_module, 'run_opensearch_ingest_pipeline_tests') as mock:
+        yield mock
+
+
+class TestGetOpenSearchIngestPipelineTestsBody:
+    def test_should_parse_pipeline_definition_as_json(self):
+        body = get_opensearch_ingest_pipeline_tests_body(
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+        assert body['pipeline'] == json.loads(OPENSEARCH_INGEST_PIPELINE_CONFIG_1.definition)
+
+    def test_should_include_input_documents_as_source(self):
+        body = get_opensearch_ingest_pipeline_tests_body(
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+        assert len(body['docs']) == 1
+        assert body['docs'][0]['_source'] == (
+            OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.input_document
+        )
+
+
+class TestGetOpenSearchIngestPipelineTestActualDocumentsFromSimulateResponse:
+    def test_should_extract_actual_documents_from_source(self):
+        actual_documents = (
+            get_opensearch_ingest_pipeline_test_actual_documents_from_simulate_response({
+                'docs': [{
+                    'doc': {
+                        '_source': OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document
+                    }
+                }]
+            })
+        )
+        assert actual_documents == [OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document]
+
+
+class TestAssertOpenSearchIngestPipelineTestActualDocumentsMatchExpected:
+    def test_should_pass_if_actual_documents_match_expected_documents(self):
+        assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+            actual_documents=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1.expected_document],
+            ingest_pipeline_config=dataclasses.replace(
+                OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+            )
+        )
+
+    def test_should_raise_assertion_error_for_not_matching_documents(self):
+        with pytest.raises(AssertionError):
+            assert_opensearch_ingest_pipeline_test_actual_documents_match_expected(
+                actual_documents=[{'name': 'not matching actual document'}],
+                ingest_pipeline_config=dataclasses.replace(
+                    OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+                    tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+                )
+            )
+
+
+class TestRunOpenSearchIngestPipelineTests:
+    def test_should_simulate_and_assert_documents_match(
+        self,
+        opensearch_client_mock: MagicMock,
+        assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock: MagicMock
+    ):
+        ingest_pipeline_config = dataclasses.replace(
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+            tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+        )
+        opensearch_client_mock.ingest.simulate.return_value = {
+            'docs': [{
+                'doc': {
+                    '_source': {'name': 'actual document 1'}
+                }
+            }]
+        }
+        run_opensearch_ingest_pipeline_tests(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+        opensearch_client_mock.ingest.simulate.assert_called_with(
+            body=get_opensearch_ingest_pipeline_tests_body(
+                ingest_pipeline_config
+            )
+        )
+        (
+            assert_opensearch_ingest_pipeline_test_actual_documents_match_expected_mock
+            .assert_called_with(
+                actual_documents=[{'name': 'actual document 1'}],
+                ingest_pipeline_config=ingest_pipeline_config
+            )
+        )
+
+
+class TestCreateOrUpdateOpenSearchIngestPipeline:
+    def test_should_put_ingest_pipeline(
+        self,
+        opensearch_client_mock: MagicMock
+    ):
+        create_or_update_opensearch_ingest_pipeline(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=OPENSEARCH_INGEST_PIPELINE_CONFIG_1
+        )
+        opensearch_client_mock.ingest.put_pipeline.assert_called_with(
+            id=OPENSEARCH_INGEST_PIPELINE_CONFIG_1.name,
+            body=OPENSEARCH_INGEST_PIPELINE_CONFIG_1.definition
+        )
+
+    def test_should_run_ingest_pipeline_tests_if_defined(
+        self,
+        opensearch_client_mock: MagicMock,
+        run_opensearch_ingest_pipeline_tests_mock: MagicMock
+    ):
+        ingest_pipeline_config = dataclasses.replace(
+            OPENSEARCH_INGEST_PIPELINE_CONFIG_1,
+            tests=[OPENSEARCH_INGEST_PIPELINE_TEST_CONFIG_1]
+        )
+        create_or_update_opensearch_ingest_pipeline(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
+        )
+        run_opensearch_ingest_pipeline_tests_mock.assert_called_with(
+            client=opensearch_client_mock,
+            ingest_pipeline_config=ingest_pipeline_config
+        )


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/963

This makes it easier to ensure that the ingest pipelines work correctly before updating the ingest pipeline.