### PR TITLE
allow the kubernetes api-server to be contacted via docker service name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ x-airflow-env:
     - BIGQUERY_TO_OPENSEARCH_CONFIG_FILE_PATH=/home/airflow/sample_data_config/opensearch/bigquery-to-opensearch.yaml
     - OPENSEARCH_USERNAME_FILE_PATH=/home/airflow/sample_data_config/opensearch/test-opensearch-username.txt
     - OPENSEARCH_PASSWORD_FILE_PATH=/home/airflow/sample_data_config/opensearch/test-opensearch-password.txt
-    - KUBECONFIG=/home/airflow/k3s-config/kubeconfig.yaml
+    - KUBECONFIG=/home/airflow/k3s-config/kubeconfig_corrected.yaml
 
 x-airflow-volumes:
   &airflow-volumes
@@ -129,6 +129,7 @@ services:
           - smtp-server
           - redis
           - scheduler
+          - fix-k3s-config
         volumes: *airflow-volumes
         image: elifesciences/data-hub-core-dags-dev
         entrypoint: /entrypoint
@@ -143,7 +144,7 @@ services:
         environment:
             - FTP_PASS=password1
             - FTP_USER=elinks
-        volumes: 
+        volumes:
             - ./testftp_server_config/vsftpd.conf:/tmp/vsftpd.conf
         command: >
             sh -c "install -D /tmp/vsftpd.conf -m 644 /etc/
@@ -221,7 +222,7 @@ services:
 
     k3s-server:
         image: "rancher/k3s:${K3S_VERSION:-latest}"
-        command: server
+        command: server --tls-san "k3s-server"
         tmpfs:
             - /run
             - /var/run
@@ -243,6 +244,12 @@ services:
             - 6443:6443  # Kubernetes API Server
             # - 80:80      # Ingress controller port 80
             # - 443:443    # Ingress controller port 443
+
+    fix-k3s-config:
+        image: ubuntu
+        command: bash -c "cat /k3s-config/kubeconfig.yaml | sed 's/127.0.0.1/k3s-server/g' | tee /k3s-config/kubeconfig_corrected.yaml"
+        volumes:
+            - ./k3s-config:/k3s-config
 
     k3s-agent:
         image: "rancher/k3s:${K3S_VERSION:-latest}"


### PR DESCRIPTION
allow the kubernetes api-server to be contacted via docker service name, and fix kubernetes config up on worker to do so

You may think there is a better way to do the fixing of the config for the worker, and I can see that it is ripe for race conditions, depending on what order you start services, but this works from nothing:

```
> make k3s-start-detach airflow-initdb airflow-start-detach
docker-compose up --detach k3s-server k3s-agent
[+] Running 4/4
 ✔ Network data-hub-core-airflow-dags_default                       Created                                                                                                                                                                               0.0s
 ✔ Volume "data-hub-core-airflow-dags_opensearch-data-airflow-dev"  Created                                                                                                                                                                               0.0s
 ✔ Container data-hub-core-airflow-dags-k3s-agent-1                 Started                                                                                                                                                                               0.2s
 ✔ Container data-hub-core-airflow-dags-k3s-server-1                Started                                                                                                                                                                               0.2s
docker-compose run --rm  webserver db init
[+] Creating 9/6
 ✔ Container data-hub-core-airflow-dags-redis-1                                                                                                               Created                                                                                     0.1s
 ✔ Container data-hub-core-airflow-dags-postgres-1                                                                                                            Created                                                                                     0.1s
 ✔ Container data-hub-core-airflow-dags-smtp-server-1                                                                                                         Created                                                                                     0.1s
 ✔ Container data-hub-core-airflow-dags-fix-k3s-config-1                                                                                                      Created                                                                                     0.1s
 ✔ Container data-hub-core-airflow-dags-scheduler-1                                                                                                           Created                                                                                     0.1s
 ✔ Container data-hub-core-airflow-dags-worker-1                                                                                                              Created                                                                                     0.1s
[+] Running 6/6
 ✔ Container data-hub-core-airflow-dags-smtp-server-1     Started                                                                                                                                                                                         0.3s
 ✔ Container data-hub-core-airflow-dags-redis-1           Started                                                                                                                                                                                         0.2s
 ✔ Container data-hub-core-airflow-dags-postgres-1        Started                                                                                                                                                                                         0.3s
 ✔ Container data-hub-core-airflow-dags-fix-k3s-config-1  Started                                                                                                                                                                                         0.3s
 ✔ Container data-hub-core-airflow-dags-scheduler-1       Started                                                                                                                                                                                         0.3s
 ✔ Container data-hub-core-airflow-dags-worker-1          Started                                                                                                                                                                                         0.3s

/home/airflow/.local/lib/python3.8/site-packages/airflow/cli/commands/db_command.py:43 DeprecationWarning: `db init` is deprecated.  Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections
DB: postgresql+psycopg2://airflow:***@postgres:5432/airflow
[2024-08-15T13:10:34.582+0000] {migration.py:213} INFO - Context impl PostgresqlImpl.
[2024-08-15T13:10:34.583+0000] {migration.py:216} INFO - Will assume transactional DDL.
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running stamp_revision  -> 405de8318b3a
Initialization done
docker-compose up --detach worker webserver test-ftpserver
[+] Running 9/9
 ✔ Container data-hub-core-airflow-dags-smtp-server-1                                                                                                       Running                                                                                       0.0s
 ✔ Container data-hub-core-airflow-dags-test-ftpserver-1                                                                                                    Started                                                                                       0.4s
 ✔ Container data-hub-core-airflow-dags-postgres-1                                                                                                          Running                                                                                       0.0s
 ✔ Container data-hub-core-airflow-dags-fix-k3s-config-1                                                                                                    Started                                                                                       0.4s
 ✔ Container data-hub-core-airflow-dags-redis-1                                                                                                             Running                                                                                       0.0s
 ✔ Container data-hub-core-airflow-dags-scheduler-1                                                                                                         Running                                                                                       0.0s
 ✔ Container data-hub-core-airflow-dags-worker-1                                                                                                            Started                                                                                       0.5s
 ✔ Container data-hub-core-airflow-dags-webserver-1                                                                                                         Started                                                                                       0.6s

> docker compose exec worker bash
airflow@worker:/opt/airflow$    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0    286      0 --:--:-- --:--:-- --:--:--   288
100 53.7M  100 53.7M    0     0  12.4M      0  0:00:04  0:00:04 --:--:-- 16.6M
airflow@worker:/opt/airflow$ chmod +x kubectl
airflow@worker:/opt/airflow$ ./kubectl get no
NAME           STATUS   ROLES                  AGE   VERSION
19b369225b86   Ready    <none>                 29s   v1.30.2+k3s2
fc135a46ed4c   Ready    control-plane,master   37s   v1.30.2+k3s2
airflow@worker:/opt/airflow$ echo $KUBECONFIG
/home/airflow/k3s-config/kubeconfig_corrected.yaml
airflow@worker:/opt/airflow$ cat $KUBECONFIG | grep 6443
    server: https://k3s-server:6443
```