### PR TITLE
Added make target to run eLife articles XML pipeline via docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,16 @@ end2end-test:
 	$(MAKE) clean
 
 
+data-hub-pipelines-shell:
+	$(DOCKER_COMPOSE) run --rm data-hub-pipelines \
+	bash
+
+
+data-hub-pipelines-run-elife-articles-xml:
+	$(DOCKER_COMPOSE) run --rm data-hub-pipelines \
+	python -m data_pipeline.elife_article_xml.cli
+
+
 ci-test-exclude-e2e: build-dev
 	$(MAKE) DOCKER_COMPOSE="$(DOCKER_COMPOSE_CI)" \
 		test-exclude-e2e

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,6 +56,7 @@ services:
     data-hub-pipelines:
         <<: *x-airflow-defaults
         environment:
+            - DEPLOYMENT_ENV=${DATA_HUB_DEPLOYMENT_ENV}
             - GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials.json
             - PYTHONPATH=/home/airflow/.local/lib/python3.8/site-packages
         user: 0:0

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,6 +23,12 @@ x-airflow-volumes:
     - ./data_pipeline:/opt/airflow/data_pipeline
     - ./tests:/opt/airflow/tests
 
+x-airflow-defaults:
+  &x-airflow-defaults
+    volumes: *airflow-volumes
+    environment: *airflow-env
+
+
 services:
     data-hub-dags-dev:
         volumes: *airflow-volumes
@@ -46,6 +52,13 @@ services:
     test-client:
         volumes: *airflow-volumes
         environment: *airflow-env
+
+    data-hub-pipelines:
+        <<: *x-airflow-defaults
+        environment:
+            - GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials.json
+            - PYTHONPATH=/home/airflow/.local/lib/python3.8/site-packages
+        user: 0:0
 
     test-ftpserver:
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,11 @@ services:
             && sudo install -D /tmp/.aws-credentials -m 644 --no-target-directory /home/airflow/.aws/credentials
             && ./run_test.sh with-end-to-end"
 
+    data-hub-pipelines:
+        image:  ${IMAGE_REPO}:${IMAGE_TAG}
+        environment: *airflow-env
+        volumes: *airflow-volumes
+
     postgres:
         image: postgres:15
         environment:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/961

This is to test whether the CLI is working with the Docker image.
We could use that command to test that an alternative image is still working.