### PR TITLE
Add image pull policy to kubernetes pipeline config

### DIFF
--- a/dags/kubernetes_pipeline.py
+++ b/dags/kubernetes_pipeline.py
@@ -45,6 +45,7 @@ def create_kubernetes_pipeline_dags() -> Sequence[airflow.DAG]:
                 task_id=deployment_env + '-' + kubernetes_pipeline_config.data_pipeline_id,
                 random_name_suffix=True,
                 image=kubernetes_pipeline_config.image,
+                image_pull_policy=kubernetes_pipeline_config.image_pull_policy,
                 arguments=kubernetes_pipeline_config.arguments,
                 do_xcom_push=False,
                 startup_timeout_seconds=600,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/966

Currently we are using the `latest` tag. That is why we want to configure the image pull policy to `Always` so that it will always check for updates rather than just use the previously downloaded version.

We have already added the configuration, but didn't pass it to the `KubernetesPodOperator`. This PR fixes.

(In the future we want to avoid using `latest` though)