### PR TITLE
Fixed pendulum version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ dateparser==1.2.0
 kubernetes==23.6.0
 apache-airflow-providers-cncf-kubernetes==7.5.0
 objsize==0.7.0
+pendulum==2.1.2
 regex==2023.12.25
 fsspec==2022.8.2
 lxml>=4.8.0, <5.2.0


### PR DESCRIPTION
Pinned pendulum==2.1.2, same as in data-science-dags.

>   File "/home/$USER/_git_/elife/data-pipeline/data-hub-core-airflow-dags/venv/lib/python3.8/site-packages/airflow/utils/session.py", line 24, in <module>
>     from airflow import settings
>   File "/home/$USER/_git_/elife/data-pipeline/data-hub-core-airflow-dags/venv/lib/python3.8/site-packages/airflow/settings.py", line 51, in <module>
>     TIMEZONE = pendulum.tz.timezone("UTC")
> TypeError: 'module' object is not callable