### PR TITLE
Web API: OpenAlex/Crossref: Combine static filters with dynamic ones

### DIFF
--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -90,7 +90,7 @@ class WebApiDynamicRequestBuilder:
                 self.url_excluding_configurable_parameters,
                 placeholder_values
             ),
-            parameters=parameters_key_value
+            parameters=get_non_empty_parameters(parameters_key_value)
         )
         LOGGER.debug('composed_url: %r', composed_url)
         return composed_url

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -74,9 +74,9 @@ class WebApiDynamicRequestBuilder:
             placeholder_values
         )
         parsed_url = parse.urlparse(url)
-        parsed_qs = parse.parse_qs(parsed_url.query)
+        params_from_url = parse.parse_qs(parsed_url.query)
         combined_query_params = {
-            **parsed_qs,
+            **params_from_url,
             **get_non_empty_parameters(parameters_key_value)
         }
         LOGGER.debug('combined_query_params: %r', combined_query_params)

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -56,17 +56,6 @@ class WebApiDynamicRequestBuilder:
     ) -> Optional[Any]:
         return None
 
-    def _get_url_separator(self) -> str:
-        url = self.url_excluding_configurable_parameters
-        if "?" in url:
-            if url.strip().endswith("&") or url.strip().endswith("?"):
-                url_separator = ""
-            else:
-                url_separator = "&"
-        else:
-            url_separator = "?"
-        return url_separator
-
     def compose_url(
         self,
         parameters_key_value: dict,

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -207,17 +207,6 @@ class BioRxivWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
         ])
 
 
-# def urlunparse(
-#     scheme: str,
-#     netloc: str,
-#     path: str,
-#     params: str = '',
-#     query: str = '',
-#     fragment: str = ''
-# ) -> str:
-#     return parse.urlunparse([scheme, netloc, path, params, query, fragment])
-
-
 class CrossrefMetadataWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
     def __init__(self, **kwargs):
         super().__init__(**{

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -29,6 +29,14 @@ class WebApiDynamicRequestParameters(NamedTuple):
     placeholder_values: Optional[dict] = None
 
 
+def get_non_empty_parameters(parameters: dict) -> dict:
+    return {
+        key: value
+        for key, value in parameters.items()
+        if key and value
+    }
+
+
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 @dataclass(frozen=True)
 class WebApiDynamicRequestBuilder:
@@ -65,11 +73,7 @@ class WebApiDynamicRequestBuilder:
             self.url_excluding_configurable_parameters,
             placeholder_values
         )
-        filtered_params = {
-            key: value
-            for key, value in parameters_key_value.items()
-            if key and value
-        }
+        filtered_params = get_non_empty_parameters(parameters_key_value)
         parsed_url = parse.urlparse(url)
         parsed_qs = parse.parse_qs(parsed_url.query)
         combined_query_params = {

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -85,12 +85,11 @@ class WebApiDynamicRequestBuilder:
         parameters_key_value: dict,
         placeholder_values: Optional[dict] = None
     ) -> str:
-        url = replace_placeholders(
-            self.url_excluding_configurable_parameters,
-            placeholder_values
-        )
         composed_url = get_url_with_added_or_replaced_query_parameters(
-            url,
+            url=replace_placeholders(
+                self.url_excluding_configurable_parameters,
+                placeholder_values
+            ),
             parameters=parameters_key_value
         )
         LOGGER.debug('composed_url: %r', composed_url)

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -37,6 +37,22 @@ def get_non_empty_parameters(parameters: dict) -> dict:
     }
 
 
+def get_url_with_added_or_replaced_query_parameters(
+    url: str,
+    parameters: dict
+) -> str:
+    parsed_url = parse.urlparse(url)
+    params_from_url = parse.parse_qs(parsed_url.query)
+    combined_query_params = {
+        **params_from_url,
+        **parameters
+    }
+    LOGGER.debug('combined_query_params: %r', combined_query_params)
+    return parse.urlunparse(
+        parsed_url._replace(query=parse.urlencode(combined_query_params))
+    )
+
+
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 @dataclass(frozen=True)
 class WebApiDynamicRequestBuilder:
@@ -73,15 +89,9 @@ class WebApiDynamicRequestBuilder:
             self.url_excluding_configurable_parameters,
             placeholder_values
         )
-        parsed_url = parse.urlparse(url)
-        params_from_url = parse.parse_qs(parsed_url.query)
-        combined_query_params = {
-            **params_from_url,
-            **get_non_empty_parameters(parameters_key_value)
-        }
-        LOGGER.debug('combined_query_params: %r', combined_query_params)
-        composed_url = parse.urlunparse(
-            parsed_url._replace(query=parse.urlencode(combined_query_params))
+        composed_url = get_url_with_added_or_replaced_query_parameters(
+            url,
+            parameters=parameters_key_value
         )
         LOGGER.debug('composed_url: %r', composed_url)
         return composed_url

--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -73,12 +73,11 @@ class WebApiDynamicRequestBuilder:
             self.url_excluding_configurable_parameters,
             placeholder_values
         )
-        filtered_params = get_non_empty_parameters(parameters_key_value)
         parsed_url = parse.urlparse(url)
         parsed_qs = parse.parse_qs(parsed_url.query)
         combined_query_params = {
             **parsed_qs,
-            **filtered_params
+            **get_non_empty_parameters(parameters_key_value)
         }
         LOGGER.debug('combined_query_params: %r', combined_query_params)
         composed_url = parse.urlunparse(

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -133,16 +133,25 @@ webApi:
   - dataPipelineId: openalex_works_metadata_for_preprints
     description:
       Retrieve OpenAlex metadata for all of the preprints.
-      Currently this will get all of the preprints every time because we do not yet have premium access.
+      Currently this will use the publication date to chunk data.
+      It is recommended to use the `updated_date` which requires premium access.
     dataset: '{ENV}'
     table: test_openalex_works_api_response
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/generic-web-api/{ENV}-openalex-preprints-by-publication-date.json'
     urlSourceType:
       # Note: We currently need to use `crossref_metadata_api` for the cursor parameter to work
       name: 'crossref_metadata_api'
     dataUrl:
-      urlExcludingConfigurableParameters: 'https://api.openalex.org/works?filter=type:preprint,publication_date:2024-02-01'
+      urlExcludingConfigurableParameters: 'https://api.openalex.org/works?filter=type:preprint'
       configurableParameters:
         nextPageCursorParameterName: 'cursor'
+        fromDateParameterName: 'from_publication_date'
+        toDateParameterName: 'to_publication_date'
+        daysDiffFromStartTillEnd: 10  # load data one day at a time
+        defaultStartDate: '2024-10-01+00:00'
+        dateFormat: '%Y-%m-%d'
         pageSizeParameterName: 'per-page'
         defaultPageSize: 200
     response:
@@ -156,7 +165,7 @@ webApi:
         - count
       recordTimestamp:
         itemTimestampKeyFromItemRoot:
-          - 'updated_date'
+          - 'publication_date'
       provenanceEnabled: True
       fieldsToReturn:
         - id

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -135,6 +135,25 @@ class TestCrossrefMetadataWebApiDynamicRequestBuilder:
         params = parse_qs(url.query)
         assert params.get('filter') == ['from-index-date:2024-01-29,until-index-date:2024-01-30']
 
+    def test_should_add_from_date_as_filter_parameter_to_existing_filter_parameter_in_url(self):
+        dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=(
+                'https://test/api1?filter=existing-filter1:value1'
+            ),
+            from_date_param='from-index-date',
+            date_format=r'%Y-%m-%d',
+            static_parameters={}
+        )
+        LOGGER.debug('dynamic_request_builder: %r', dynamic_request_builder)
+        url = urlparse(dynamic_request_builder.get_url(
+            dynamic_request_parameters=WebApiDynamicRequestParameters(
+                from_date=datetime.fromisoformat('2024-01-29+00:00')
+            )
+        ))
+        LOGGER.debug('url: %r', url)
+        params = parse_qs(url.query)
+        assert params.get('filter') == ['existing-filter1:value1,from-index-date:2024-01-29']
+
     def test_should_replace_placeholders(self):
         dynamic_request_builder = CrossrefMetadataWebApiDynamicRequestBuilder(
             url_excluding_configurable_parameters=TEST_API_URL_1 + '/{placeholder}',


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/995
    
Date range parameters would be expressed as expressions within `filter` parameters. There may also be static filter parameters specified as part of the URL.
    
With this PR those parameters would get combined.
    
e.g. `urlExcludingConfigurableParameters` configured as `https://api.openalex.org/works?
filter=type:preprint`,
adding `from_publication_date` and `to_publication_date` dynamic parameters,
the url could result in something like `https://api.openalex.org/works?filter=type:preprint,from_publicatio
n_date=2001-01-01,to_publication_date=2001-01-02`.

This is currently for the request builder for Crossref where this equally makes sense. Ideally there would be a request builder for OpenAlex or something more generic.