### PR TITLE
Web API: Added sample OpenAlex config using the API key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ dev-run-elife-articles-xml:
 
 
 dev-run-web-api:  .require-DATA_PIPELINE_ID
+	OPENALEX_API_KEY_FILE_PATH=.secrets/openalex-api-key.txt \
 	WEB_API_CONFIG_FILE_PATH=sample_data_config/web-api/web-api-data-pipeline.config.yaml \
 		$(PYTHON) -m data_pipeline.generic_web_api.cli \
 		--data-pipeline-id=$(DATA_PIPELINE_ID) $(ARGS)

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -201,3 +201,77 @@ webApi:
         - primary_location
         - best_oa_location
         - related_works
+
+  - dataPipelineId: openalex_works_metadata_for_preprints_by_updated_date
+    description:
+      Retrieve OpenAlex metadata for all of the preprints.
+      Currently this will use the publication date to chunk data.
+      It is recommended to use the `updated_date` which requires premium access.
+      This pipeline only works with the API key.
+    dataset: '{ENV}'
+    table: test_openalex_works_api_response
+    stateFile:
+      bucketName: '{ENV}-elife-data-pipeline'
+      objectName: 'airflow-config/generic-web-api/{ENV}-openalex-preprints-by-updated-date.json'
+    retry:
+      maxRetryCount: 10
+      retryBackoffFactor: 1
+      retryOnResponseStatusList:
+        - 429
+        - 500
+        - 502
+        - 504
+    headers:
+      parametersFromFile:
+        - parameterName: api_key
+          filePathEnvName: OPENALEX_API_KEY_FILE_PATH
+    urlSourceType:
+      # Note: We currently need to use `crossref_metadata_api` for the cursor parameter to work
+      name: 'crossref_metadata_api'
+    dataUrl:
+      urlExcludingConfigurableParameters: 'https://api.openalex.org/works?filter=type:preprint'
+      configurableParameters:
+        nextPageCursorParameterName: 'cursor'
+        fromDateParameterName: 'from_updated_date'
+        toDateParameterName: 'to_updated_date'
+        daysDiffFromStartTillEnd: 10  # load data one day at a time
+        defaultStartDate: '2024-11-10+00:00'
+        # Note: OpenAlex do not seem to use timezones
+        dateFormat: '%Y-%m-%dT%H:%M:%S.%f'
+        pageSizeParameterName: 'per-page'
+        defaultPageSize: 200
+    response:
+      nextPageCursorKeyFromResponseRoot:
+        - meta
+        - next_cursor
+      itemsKeyFromResponseRoot:
+        - results
+      totalItemsCountKeyFromResponseRoot:
+        - meta
+        - count
+      recordTimestamp:
+        itemTimestampKeyFromItemRoot:
+          - 'updated_date'
+      onSameNextCursor: Error
+      provenanceEnabled: True
+      fieldsToReturn:
+        - id
+        - doi
+        - type
+        - type_crossref
+        - indexed_in
+        - open_access
+        - title
+        - authorships
+        - concepts
+        - primary_topic
+        - topics
+        - keywords
+        - created_date
+        - updated_date
+        - publication_date
+        - language
+        - locations
+        - primary_location
+        - best_oa_location
+        - related_works


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1019

We've now applied this to staging.
But the sample config is there to be able to test it locally.
I left the previous config there as well, so that it can be tested without the API key (although not using `updated_date`).