### PR TITLE
Web API: Process placeholders in base request builder

### DIFF
--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -116,7 +116,10 @@ class WebApiDynamicRequestBuilder:
             **self.static_parameters
         }
 
-        return self.compose_url(param_dict)
+        return self.compose_url(
+            parameters_key_value=param_dict,
+            placeholder_values=dynamic_request_parameters.placeholder_values
+        )
 
 
 CiviFieldsToReturnDict = TypedDict(

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 from data_pipeline.generic_web_api.request_builder import (
     CrossrefMetadataWebApiDynamicRequestBuilder,
     S2TitleAbstractEmbeddingsWebApiDynamicRequestBuilder,
+    WebApiDynamicRequestBuilder,
     get_url_with_added_or_replaced_query_parameters,
     get_web_api_request_builder_class,
     BioRxivWebApiDynamicRequestBuilder,
@@ -36,6 +37,21 @@ class TestGetUrlWithAddedOrReplacedQueryParameters:
             'https://test/api1?existing-param=old-value',
             parameters={'new-param': 'new-value'}
         ) == 'https://test/api1?existing-param=old-value&new-param=new-value'
+
+
+class TestWebApiDynamicRequestBuilder:
+    def test_should_replace_placeholders(self):
+        dynamic_request_builder = WebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1 + '/{placeholder}',
+            static_parameters={}
+        )
+        url = dynamic_request_builder.get_url(
+            dynamic_request_parameters=WebApiDynamicRequestParameters(
+                placeholder_values={'placeholder': 'buddy1'}
+            )
+        )
+        LOGGER.debug('url: %r', url)
+        assert url.rstrip('?') == TEST_API_URL_1 + '/buddy1'
 
 
 class TestDynamicBioRxivMedRxivURLBuilder:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1021

This will allow us to use the base / default request builder instead of using the Crossref related request builder just to process placeholders.