### PR TITLE
Web API: load biorxiv mecapath v2 results in batches

### DIFF
--- a/data_pipeline/generic_web_api/request_builder.py
+++ b/data_pipeline/generic_web_api/request_builder.py
@@ -122,6 +122,28 @@ class WebApiDynamicRequestBuilder:
         )
 
 
+class SingleSourceValueWebApiDynamicRequestBuilder(WebApiDynamicRequestBuilder):
+    def __init__(self, **kwargs):
+        super().__init__(**{
+            **kwargs,
+            'max_source_values_per_request': 1
+        })
+
+    def get_url(
+        self,
+        dynamic_request_parameters: WebApiDynamicRequestParameters
+    ) -> str:
+        assert dynamic_request_parameters.source_values is not None
+        source_values = list(dynamic_request_parameters.source_values)
+        assert len(source_values) == 1
+        placeholder_values = source_values[0]
+        return super().get_url(
+            dynamic_request_parameters=dynamic_request_parameters._replace(
+                placeholder_values=placeholder_values
+            )
+        )
+
+
 CiviFieldsToReturnDict = TypedDict(
     'CiviFieldsToReturnDict',
     {
@@ -284,6 +306,7 @@ class S2TitleAbstractEmbeddingsWebApiDynamicRequestBuilder(WebApiDynamicRequestB
 
 
 WEB_API_REQUEST_BUILDER_CLASS_BY_NAME_MAP: Mapping[str, Type[WebApiDynamicRequestBuilder]] = {
+    'single_source_value': SingleSourceValueWebApiDynamicRequestBuilder,
     'civi': CiviWebApiDynamicRequestBuilder,
     'biorxiv_medrxiv_api': BioRxivWebApiDynamicRequestBuilder,
     's2_title_abstract_embeddings_api': S2TitleAbstractEmbeddingsWebApiDynamicRequestBuilder,

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -162,12 +162,12 @@ webApi:
             JOIN UNNEST(results) AS meca_path_metadata
         keyFieldNameFromInclude: 'biorxiv_versioned_doi'
     urlSourceType:
-      name: 'crossref_metadata_api'
+      name: 'single_source_value'
     dataUrl:
       urlExcludingConfigurableParameters: https://api.biorxiv.org/meca_index_v2/elife/{biorxiv_versioned_doi}
     response:
       provenanceEnabled: True
-    batchSize: 10
+    batchSize: 19
 
   - dataPipelineId: openalex_works_metadata_for_preprints
     description:

--- a/tests/unit_test/generic_web_api/request_builder_test.py
+++ b/tests/unit_test/generic_web_api/request_builder_test.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qs, urlparse
 from data_pipeline.generic_web_api.request_builder import (
     CrossrefMetadataWebApiDynamicRequestBuilder,
     S2TitleAbstractEmbeddingsWebApiDynamicRequestBuilder,
+    SingleSourceValueWebApiDynamicRequestBuilder,
     WebApiDynamicRequestBuilder,
     get_url_with_added_or_replaced_query_parameters,
     get_web_api_request_builder_class,
@@ -48,6 +49,28 @@ class TestWebApiDynamicRequestBuilder:
         url = dynamic_request_builder.get_url(
             dynamic_request_parameters=WebApiDynamicRequestParameters(
                 placeholder_values={'placeholder': 'buddy1'}
+            )
+        )
+        LOGGER.debug('url: %r', url)
+        assert url.rstrip('?') == TEST_API_URL_1 + '/buddy1'
+
+
+class TestSingleSourceValueWebApiDynamicRequestBuilder:
+    def test_should_set_max_source_values_per_request_to_one(self):
+        dynamic_request_builder = SingleSourceValueWebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1,
+            static_parameters={}
+        )
+        assert dynamic_request_builder.max_source_values_per_request == 1
+
+    def test_should_use_single_source_value_as_placeholders(self):
+        dynamic_request_builder = SingleSourceValueWebApiDynamicRequestBuilder(
+            url_excluding_configurable_parameters=TEST_API_URL_1 + '/{placeholder}',
+            static_parameters={}
+        )
+        url = dynamic_request_builder.get_url(
+            dynamic_request_parameters=WebApiDynamicRequestParameters(
+                source_values=iter([{'placeholder': 'buddy1'}])
             )
         )
         LOGGER.debug('url: %r', url)


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1021

This will make the pipeline run more efficient and avoid BigQuery quota issues.