### PR TITLE
Downgraded redis to 4.6.0 to solve dependency issue with celery and kombu

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ kubernetes==23.6.0
 apache-airflow-providers-cncf-kubernetes==7.5.0
 objsize==0.7.0
 pendulum==2.1.2
+redis==4.6.0
 regex==2024.11.6
 fsspec==2022.8.2
 lxml>=4.8.0, <5.2.0


### PR DESCRIPTION
https://github.com/elifesciences/data-hub-issues/issues/1051