### PR TITLE
Web API: Configurable timeout parameter

### DIFF
--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -28,6 +28,7 @@ from data_pipeline.generic_web_api.generic_web_api_config_typing import (
     WebApiResponseConfigDict,
     OnSameNextCursorConfig
 )
+from data_pipeline.utils.pipeline_utils import DEFAULT_TIMEOUT
 from data_pipeline.utils.record_processing import RecordProcessingStepFunction
 from data_pipeline.utils.record_processing_functions import (
     get_single_record_processing_step_function_for_function_names_or_none
@@ -36,9 +37,6 @@ from data_pipeline.utils.web_api import (
     DEFAULT_WEB_API_RETRY_CONFIG,
     WebApiRetryConfig
 )
-
-DEFAULT_TIMEOUT = 10
-
 
 def get_resolved_parameter_values_from_env_name(
     parameters_from_env_name: Sequence[ParameterFromEnvConfigDict]

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -307,6 +307,7 @@ class WebApiConfig:
             state_file_object_name=(
                 api_config.get("stateFile", {}).get("objectName")
             ),
+            timeout=api_config.get('timeout', DEFAULT_TIMEOUT),
             retry=WebApiRetryConfig.from_optional_dict(
                 api_config.get('retry')
             ),

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -38,6 +38,7 @@ from data_pipeline.utils.web_api import (
     WebApiRetryConfig
 )
 
+
 def get_resolved_parameter_values_from_env_name(
     parameters_from_env_name: Sequence[ParameterFromEnvConfigDict]
 ):

--- a/data_pipeline/generic_web_api/generic_web_api_config.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config.py
@@ -37,6 +37,8 @@ from data_pipeline.utils.web_api import (
     WebApiRetryConfig
 )
 
+DEFAULT_TIMEOUT = 10
+
 
 def get_resolved_parameter_values_from_env_name(
     parameters_from_env_name: Sequence[ParameterFromEnvConfigDict]
@@ -164,6 +166,7 @@ class WebApiConfig:
     dynamic_request_builder: WebApiDynamicRequestBuilder
     gcp_project: str
     response: WebApiResponseConfig
+    timeout: float = DEFAULT_TIMEOUT
     retry: WebApiRetryConfig = DEFAULT_WEB_API_RETRY_CONFIG
     schema_file_s3_bucket: Optional[str] = None
     schema_file_object_name: Optional[str] = None

--- a/data_pipeline/generic_web_api/generic_web_api_config_typing.py
+++ b/data_pipeline/generic_web_api/generic_web_api_config_typing.py
@@ -91,6 +91,7 @@ class WebApiBaseConfigDict(TypedDict):
     dataUrl: WebApiDataUrlConfigDict
     authentication: NotRequired[WebApiAuthenticationConfigDict]
     headers: NotRequired[MappingConfigDict]
+    timeout: NotRequired[float]
     retry: NotRequired[WebApiRetryConfigDict]
     requestBuilder: NotRequired[WebApiRequestBuilderConfigDict]
     response: NotRequired[WebApiResponseConfigDict]

--- a/data_pipeline/generic_web_api/generic_web_api_data_etl.py
+++ b/data_pipeline/generic_web_api/generic_web_api_data_etl.py
@@ -168,7 +168,8 @@ def get_data_single_page_response(
             url=url,
             json_data=json_data,
             headers=data_config.headers.mapping,
-            raise_on_status=True
+            raise_on_status=True,
+            timeout=data_config.timeout
         )
         LOGGER.info('Request Provenance: %r', request_provenance)
         resp = session_response.content

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -149,7 +149,7 @@ def get_response_and_provenance_from_api(  # noqa pylint: disable=too-many-argum
     json_data: Optional[Any] = None,
     provenance: Optional[Mapping[str, str]] = None,
     session: Optional[requests.Session] = None,
-    timeout: Optional[float] = None,
+    timeout: float = DEFAULT_TIMEOUT,
     raise_on_status: bool = True,
     progress_message: Optional[str] = None
 ) -> Tuple[requests.Response, dict]:

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -21,6 +21,8 @@ from data_pipeline.utils.pipeline_config import (
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT = 10
+
 
 def fetch_single_column_value_list_for_bigquery_source_config(
     bigquery_source_config: BigQuerySourceConfig

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -178,7 +178,12 @@ def get_response_and_provenance_from_api(  # noqa pylint: disable=too-many-argum
         )
     else:
         response = requests.request(
-            method, url, params=params, headers=headers, json=json_data, timeout=10
+            method,
+            url,
+            params=params,
+            headers=headers,
+            json=json_data,
+            timeout=timeout
         )
     response_timestamp = datetime.utcnow()
     LOGGER.debug('raise_on_status: %r', raise_on_status)

--- a/data_pipeline/utils/pipeline_utils.py
+++ b/data_pipeline/utils/pipeline_utils.py
@@ -147,6 +147,7 @@ def get_response_and_provenance_from_api(  # noqa pylint: disable=too-many-argum
     json_data: Optional[Any] = None,
     provenance: Optional[Mapping[str, str]] = None,
     session: Optional[requests.Session] = None,
+    timeout: Optional[float] = None,
     raise_on_status: bool = True,
     progress_message: Optional[str] = None
 ) -> Tuple[requests.Response, dict]:
@@ -165,7 +166,14 @@ def get_response_and_provenance_from_api(  # noqa pylint: disable=too-many-argum
     )
     request_timestamp = datetime.utcnow()
     if session:
-        response = session.request(method, url, params=params, headers=headers, json=json_data)
+        response = session.request(
+            method,
+            url,
+            params=params,
+            headers=headers,
+            json=json_data,
+            timeout=timeout
+        )
     else:
         response = requests.request(
             method, url, params=params, headers=headers, json=json_data, timeout=10

--- a/sample_data_config/web-api/web-api-data-pipeline.config.yaml
+++ b/sample_data_config/web-api/web-api-data-pipeline.config.yaml
@@ -96,6 +96,7 @@ webApi:
     stateFile:
       bucketName: '{ENV}-elife-data-pipeline'
       objectName: 'airflow-config/generic-web-api/{ENV}-crossref-metadata-state/{doi_prefix}.json'
+    timeout: 10
     retry:
       maxRetryCount: 0
       retryOnResponseStatusList: []

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -15,6 +15,7 @@ from data_pipeline.utils.pipeline_config import (
 
 from data_pipeline.generic_web_api import generic_web_api_config as generic_web_api_config_module
 from data_pipeline.generic_web_api.generic_web_api_config import (
+    DEFAULT_TIMEOUT,
     WebApiResponseConfig,
     get_web_api_config_id,
     MultiWebApiConfig,
@@ -270,6 +271,10 @@ class TestWebApiConfig:
             web_api_config.dynamic_request_builder.max_source_values_per_request
             == DEFAULT_SPACY_BATCH_MAX_SOURCE_VALUES_PER_REQUEST
         )
+
+    def test_should_use_default_timeout(self):
+        web_api_config = WebApiConfig.from_dict(MINIMAL_WEB_API_CONFIG_DICT)
+        assert web_api_config.timeout == DEFAULT_TIMEOUT
 
     def test_should_use_default_retry(self):
         web_api_config = WebApiConfig.from_dict(MINIMAL_WEB_API_CONFIG_DICT)

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -15,7 +15,6 @@ from data_pipeline.utils.pipeline_config import (
 
 from data_pipeline.generic_web_api import generic_web_api_config as generic_web_api_config_module
 from data_pipeline.generic_web_api.generic_web_api_config import (
-    DEFAULT_TIMEOUT,
     WebApiResponseConfig,
     get_web_api_config_id,
     MultiWebApiConfig,
@@ -26,6 +25,7 @@ from data_pipeline.generic_web_api.generic_web_api_config_typing import (
     WebApiRetryConfigDict
 )
 from data_pipeline.utils.pipeline_config_typing import AirflowConfigDict
+from data_pipeline.utils.pipeline_utils import DEFAULT_TIMEOUT
 from data_pipeline.utils.web_api import DEFAULT_WEB_API_RETRY_CONFIG, WebApiRetryConfig
 from tests.unit_test.generic_web_api.test_data import (
     DATASET_1,

--- a/tests/unit_test/generic_web_api/generic_web_api_config_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_config_test.py
@@ -276,6 +276,13 @@ class TestWebApiConfig:
         web_api_config = WebApiConfig.from_dict(MINIMAL_WEB_API_CONFIG_DICT)
         assert web_api_config.timeout == DEFAULT_TIMEOUT
 
+    def test_should_use_read_config_timeout(self):
+        web_api_config = WebApiConfig.from_dict({
+            **MINIMAL_WEB_API_CONFIG_DICT,
+            'timeout': 10.5
+        })
+        assert web_api_config.timeout == 10.5
+
     def test_should_use_default_retry(self):
         web_api_config = WebApiConfig.from_dict(MINIMAL_WEB_API_CONFIG_DICT)
         assert web_api_config.retry == (

--- a/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
+++ b/tests/unit_test/generic_web_api/generic_web_api_data_etl_test.py
@@ -703,7 +703,8 @@ class TestGetDataSinglePage:
             url=dynamic_request_builder.get_url.return_value,
             json_data=dynamic_request_builder.get_json.return_value,
             headers=data_config.headers.mapping,
-            raise_on_status=True
+            raise_on_status=True,
+            timeout=data_config.timeout
         )
 
     def test_should_pass_dynamic_request_parameters_to_get_json(self):

--- a/tests/unit_test/utils/pipeline_utils_test.py
+++ b/tests/unit_test/utils/pipeline_utils_test.py
@@ -312,14 +312,16 @@ class TestGetResponseJsonWithProvenanceFromApi:
             headers=API_HEADERS_1,
             method='POST',
             json_data=JSON_DATA_1,
-            session=session_mock
+            session=session_mock,
+            timeout=12.3
         )
         session_mock.request.assert_called_with(
             'POST',
             API_URL_1,
             params=API_PARAMS_1,
             headers=API_HEADERS_1,
-            json=JSON_DATA_1
+            json=JSON_DATA_1,
+            timeout=12.3
         )
 
     def test_should_return_response_json(

--- a/tests/unit_test/utils/pipeline_utils_test.py
+++ b/tests/unit_test/utils/pipeline_utils_test.py
@@ -291,7 +291,8 @@ class TestGetResponseJsonWithProvenanceFromApi:
             params=API_PARAMS_1,
             headers=API_HEADERS_1,
             method='POST',
-            json_data=JSON_DATA_1
+            json_data=JSON_DATA_1,
+            timeout=12.3
         )
         requests_mock.request.assert_called_with(
             'POST',
@@ -299,7 +300,7 @@ class TestGetResponseJsonWithProvenanceFromApi:
             params=API_PARAMS_1,
             headers=API_HEADERS_1,
             json=JSON_DATA_1,
-            timeout=10
+            timeout=12.3
         )
 
     def test_should_pass_url_params_and_headers_to_session_request_if_provided(


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1052

This will now use a default timeout of 10 seconds that can be changed via the `timeout` configuration.