### PR TITLE
Upgraded Airflow base image to 2.8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.7.1-python3.10
+FROM apache/airflow:2.8.4-python3.10
 
 USER root
 


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1021

After upgrading the dependencies we didn't update the base image.
This is the latest base image that still works without additional modifications.