### PR TITLE
CSV pipeline: use UTC for state timestamps

### DIFF
--- a/data_pipeline/s3_csv_data/s3_csv_etl.py
+++ b/data_pipeline/s3_csv_data/s3_csv_etl.py
@@ -64,7 +64,7 @@ def get_stored_state(
     except FileNotFoundError:
         return CsvState.get_initial_state(
             object_patterns=data_config.s3_object_key_pattern_list,
-            last_modified_datetime=parse_timestamp(
+            last_modified_timestamp=parse_timestamp(
                 default_latest_file_date
             )
         )
@@ -282,7 +282,7 @@ def etl_new_csv_files(data_config: S3BaseCsvConfig):
     LOGGER.info('csv_state: %r', csv_state)
     new_s3_files = list(iter_sorted_new_s3_files_to_process(
         obj_pattern_with_latest_dates={
-            object_pattern: object_pattern_csv_state.last_modified_datetime
+            object_pattern: object_pattern_csv_state.last_modified_timestamp
             for object_pattern, object_pattern_csv_state in csv_state.state_dict.items()
         },
         s3_bucket_name=data_config.s3_bucket_name
@@ -309,9 +309,9 @@ def etl_new_csv_files(data_config: S3BaseCsvConfig):
             data_config,
             record_import_timestamp_as_string,
         )
-        csv_state.update_last_modified_datetime(
+        csv_state.update_last_modified_timestamp(
             object_pattern=object_key_pattern,
-            last_modified_datetime=matching_file_metadata.last_modified
+            last_modified_timestamp=matching_file_metadata.last_modified
         )
         upload_s3_object_json(
             state_dict=csv_state.to_dict(),

--- a/data_pipeline/s3_csv_data/s3_csv_etl.py
+++ b/data_pipeline/s3_csv_data/s3_csv_etl.py
@@ -9,7 +9,7 @@ from csv import DictReader
 import json
 from typing import Iterable, Iterator, Mapping, Optional
 
-from data_pipeline.s3_csv_data.s3_csv_state import CsvState, convert_datetime_string_to_datetime
+from data_pipeline.s3_csv_data.s3_csv_state import CsvState, parse_timestamp
 from data_pipeline.utils.data_pipeline_timestamp import get_current_timestamp_as_string
 from data_pipeline.s3_csv_data.s3_csv_config import (
     S3BaseCsvConfig,
@@ -64,7 +64,7 @@ def get_stored_state(
     except FileNotFoundError:
         return CsvState.get_initial_state(
             object_patterns=data_config.s3_object_key_pattern_list,
-            last_modified_datetime=convert_datetime_string_to_datetime(
+            last_modified_datetime=parse_timestamp(
                 default_latest_file_date
             )
         )

--- a/data_pipeline/s3_csv_data/s3_csv_state.py
+++ b/data_pipeline/s3_csv_data/s3_csv_state.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
+import logging
 from typing import Iterable, Mapping
 
-from dateutil import tz
+
+LOGGER = logging.getLogger(__name__)
 
 
 DATETIME_FORMAT = r"%Y-%m-%d %H:%M:%S"
@@ -11,10 +13,11 @@ DATETIME_FORMAT = r"%Y-%m-%d %H:%M:%S"
 def convert_datetime_string_to_datetime(
     datetime_as_string: str
 ) -> datetime:
-    tz_unaware = datetime.strptime(datetime_as_string.strip(), DATETIME_FORMAT)
-    tz_aware = tz_unaware.replace(tzinfo=tz.tzlocal())
-
-    return tz_aware
+    timestamp = datetime.fromisoformat(datetime_as_string)
+    if not timestamp.tzinfo:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    LOGGER.debug('parsed timestamp: %r => %r', datetime_as_string, timestamp)
+    return timestamp
 
 
 def convert_datetime_to_string(dtobj: datetime) -> str:

--- a/data_pipeline/s3_csv_data/s3_csv_state.py
+++ b/data_pipeline/s3_csv_data/s3_csv_state.py
@@ -21,7 +21,7 @@ def convert_datetime_string_to_datetime(
 
 
 def convert_datetime_to_string(dtobj: datetime) -> str:
-    return dtobj.strftime(DATETIME_FORMAT)
+    return dtobj.isoformat()
 
 
 @dataclass(frozen=True)

--- a/data_pipeline/s3_csv_data/s3_csv_state.py
+++ b/data_pipeline/s3_csv_data/s3_csv_state.py
@@ -20,10 +20,6 @@ def convert_datetime_string_to_datetime(
     return timestamp
 
 
-def convert_datetime_to_string(dtobj: datetime) -> str:
-    return dtobj.isoformat()
-
-
 @dataclass(frozen=True)
 class ObjectPatternCsvState:
     last_modified_datetime: datetime
@@ -62,8 +58,8 @@ class CsvState:
 
     def to_dict(self) -> Mapping[str, str]:
         return {
-            object_pattern: convert_datetime_to_string(
-                object_pattern_csv_state.last_modified_datetime
+            object_pattern: (
+                object_pattern_csv_state.last_modified_datetime.isoformat()
             )
             for object_pattern, object_pattern_csv_state in self.state_dict.items()
         }

--- a/data_pipeline/s3_csv_data/s3_csv_state.py
+++ b/data_pipeline/s3_csv_data/s3_csv_state.py
@@ -10,13 +10,11 @@ LOGGER = logging.getLogger(__name__)
 DATETIME_FORMAT = r"%Y-%m-%d %H:%M:%S"
 
 
-def convert_datetime_string_to_datetime(
-    datetime_as_string: str
-) -> datetime:
-    timestamp = datetime.fromisoformat(datetime_as_string)
+def parse_timestamp(timestamp_string: str) -> datetime:
+    timestamp = datetime.fromisoformat(timestamp_string)
     if not timestamp.tzinfo:
         timestamp = timestamp.replace(tzinfo=timezone.utc)
-    LOGGER.debug('parsed timestamp: %r => %r', datetime_as_string, timestamp)
+    LOGGER.debug('parsed timestamp: %r => %r', timestamp_string, timestamp)
     return timestamp
 
 
@@ -34,7 +32,7 @@ class CsvState:
         return CsvState(
             state_dict={
                 object_pattern: ObjectPatternCsvState(
-                    last_modified_datetime=convert_datetime_string_to_datetime(
+                    last_modified_datetime=parse_timestamp(
                         datetime_str
                     )
                 )

--- a/data_pipeline/s3_csv_data/s3_csv_state.py
+++ b/data_pipeline/s3_csv_data/s3_csv_state.py
@@ -20,7 +20,7 @@ def parse_timestamp(timestamp_string: str) -> datetime:
 
 @dataclass(frozen=True)
 class ObjectPatternCsvState:
-    last_modified_datetime: datetime
+    last_modified_timestamp: datetime
 
 
 @dataclass(frozen=True)
@@ -32,23 +32,23 @@ class CsvState:
         return CsvState(
             state_dict={
                 object_pattern: ObjectPatternCsvState(
-                    last_modified_datetime=parse_timestamp(
-                        datetime_str
+                    last_modified_timestamp=parse_timestamp(
+                        timestamp_str
                     )
                 )
-                for object_pattern, datetime_str in state_dict.items()
+                for object_pattern, timestamp_str in state_dict.items()
             }
         )
 
     @staticmethod
     def get_initial_state(
         object_patterns: Iterable[str],
-        last_modified_datetime: datetime
+        last_modified_timestamp: datetime
     ) -> 'CsvState':
         return CsvState(
             state_dict={
                 object_pattern: ObjectPatternCsvState(
-                    last_modified_datetime=last_modified_datetime
+                    last_modified_timestamp=last_modified_timestamp
                 )
                 for object_pattern in object_patterns
             }
@@ -57,16 +57,16 @@ class CsvState:
     def to_dict(self) -> Mapping[str, str]:
         return {
             object_pattern: (
-                object_pattern_csv_state.last_modified_datetime.isoformat()
+                object_pattern_csv_state.last_modified_timestamp.isoformat()
             )
             for object_pattern, object_pattern_csv_state in self.state_dict.items()
         }
 
-    def update_last_modified_datetime(
+    def update_last_modified_timestamp(
         self,
         object_pattern: str,
-        last_modified_datetime: datetime
+        last_modified_timestamp: datetime
     ):
         self.state_dict[object_pattern] = ObjectPatternCsvState(
-            last_modified_datetime=last_modified_datetime
+            last_modified_timestamp=last_modified_timestamp
         )

--- a/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
@@ -16,7 +16,7 @@ from data_pipeline.utils.data_store.s3_data_service import (
 )
 from data_pipeline.s3_csv_data import s3_csv_etl
 from data_pipeline.s3_csv_data.s3_csv_etl import (
-    convert_datetime_string_to_datetime,
+    parse_timestamp,
     etl_new_csv_files,
     get_record_metadata,
     iter_transformed_json_from_csv,
@@ -43,7 +43,7 @@ TIMESTAMP_2 = datetime.fromisoformat(TIMESTAMP_STRING_2)
 
 DATETTIME_STRING_1 = '2020-01-01 00:00:00'
 
-DATETTIME_1 = convert_datetime_string_to_datetime(DATETTIME_STRING_1)
+DATETTIME_1 = parse_timestamp(DATETTIME_STRING_1)
 
 S3_BUCKET_NAME_1 = 's3_bucket_name_1'
 
@@ -661,7 +661,7 @@ class TestStoredState:
         )
         assert state == CsvState.get_initial_state(
             object_patterns=TestStoredState.csv_config.s3_object_key_pattern_list,
-            last_modified_datetime=convert_datetime_string_to_datetime(
+            last_modified_datetime=parse_timestamp(
                 DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE
             )
         )

--- a/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
@@ -657,7 +657,7 @@ class TestStoredState:
         )
         assert state == CsvState.get_initial_state(
             object_patterns=TestStoredState.csv_config.s3_object_key_pattern_list,
-            last_modified_datetime=parse_timestamp(
+            last_modified_timestamp=parse_timestamp(
                 DEFAULT_INITIAL_S3_FILE_LAST_MODIFIED_DATE
             )
         )
@@ -668,7 +668,7 @@ class TestStoredState:
     ):
         expected_state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
         mock_download_s3_object_as_string_or_file_not_found_error.return_value = json.dumps(
@@ -715,7 +715,7 @@ class TestEtlNewCsvFiles:
     ):
         get_stored_state_mock.return_value = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
         etl_new_csv_files(
@@ -739,7 +739,7 @@ class TestEtlNewCsvFiles:
     ):
         get_stored_state_mock.return_value = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
         iter_sorted_new_s3_files_to_process_mock.return_value = iter([
@@ -768,7 +768,7 @@ class TestEtlNewCsvFiles:
     ):
         csv_state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
         get_stored_state_mock.return_value = csv_state
@@ -792,7 +792,7 @@ class TestEtlNewCsvFiles:
         })
         updated_csv_state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_2
+                last_modified_timestamp=TIMESTAMP_2
             )
         })
         etl_new_csv_files(data_config=data_config)

--- a/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_etl_test.py
@@ -41,10 +41,6 @@ TIMESTAMP_STRING_2 = '2020-01-02T00:00:00+00:00'
 TIMESTAMP_1 = datetime.fromisoformat(TIMESTAMP_STRING_1)
 TIMESTAMP_2 = datetime.fromisoformat(TIMESTAMP_STRING_2)
 
-DATETTIME_STRING_1 = '2020-01-01 00:00:00'
-
-DATETTIME_1 = parse_timestamp(DATETTIME_STRING_1)
-
 S3_BUCKET_NAME_1 = 's3_bucket_name_1'
 
 OBJECT_KEY_1 = 'object_key_1'
@@ -672,7 +668,7 @@ class TestStoredState:
     ):
         expected_state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=DATETTIME_1
+                last_modified_datetime=TIMESTAMP_1
             )
         })
         mock_download_s3_object_as_string_or_file_not_found_error.return_value = json.dumps(

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -1,5 +1,10 @@
-from data_pipeline.s3_csv_data.s3_csv_etl import convert_datetime_string_to_datetime
-from data_pipeline.s3_csv_data.s3_csv_state import CsvState, ObjectPatternCsvState
+from datetime import timezone
+
+from data_pipeline.s3_csv_data.s3_csv_state import (
+    CsvState,
+    ObjectPatternCsvState,
+    convert_datetime_string_to_datetime
+)
 
 
 DATETTIME_STRING_1 = '2020-01-01 00:00:00'
@@ -9,6 +14,22 @@ DATETTIME_1 = convert_datetime_string_to_datetime(DATETTIME_STRING_1)
 DATETTIME_2 = convert_datetime_string_to_datetime(DATETTIME_STRING_2)
 
 OBJECT_PATTERN_1 = 'object_pattern_1*'
+
+
+class TestConvertDatetimeStringToDatetime:
+    def test_should_parse_old_datetime_format(self):
+        timestamp = convert_datetime_string_to_datetime(
+            '2001-02-03 04:05:06'
+        )
+        assert timestamp.date().isoformat() == '2001-02-03'
+        assert timestamp.tzinfo == timezone.utc
+
+    def test_should_parse_timestamp(self):
+        timestamp = convert_datetime_string_to_datetime(
+            '2001-02-03T05:06:07+00:00'
+        )
+        assert timestamp.date().isoformat() == '2001-02-03'
+        assert timestamp.tzinfo == timezone.utc
 
 
 class TestCsvState:

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -7,11 +7,11 @@ from data_pipeline.s3_csv_data.s3_csv_state import (
 )
 
 
-DATETTIME_STRING_1 = '2020-01-01 00:00:00'
-DATETTIME_STRING_2 = '2020-01-02 00:00:00'
+TIMESTAMP_STRING_1 = '2020-01-01T00:00:00+00:00'
+TIMESTAMP_STRING_2 = '2020-01-02T00:00:00+00:00'
 
-DATETTIME_1 = parse_timestamp(DATETTIME_STRING_1)
-DATETTIME_2 = parse_timestamp(DATETTIME_STRING_2)
+TIMESTAMP_1 = parse_timestamp(TIMESTAMP_STRING_1)
+TIMESTAMP_2 = parse_timestamp(TIMESTAMP_STRING_2)
 
 OBJECT_PATTERN_1 = 'object_pattern_1*'
 
@@ -39,45 +39,45 @@ class TestCsvState:
 
     def test_should_parse_datetime(self):
         state = CsvState.from_dict({
-            OBJECT_PATTERN_1: DATETTIME_STRING_1
+            OBJECT_PATTERN_1: TIMESTAMP_STRING_1
         })
         assert state.state_dict == {
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=DATETTIME_1
+                last_modified_datetime=TIMESTAMP_1
             )
         }
 
     def test_should_serialize_datetime_to_string(self):
         state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=DATETTIME_1
+                last_modified_datetime=TIMESTAMP_1
             )
         })
         assert state.to_dict() == {
-            OBJECT_PATTERN_1: DATETTIME_1.isoformat()
+            OBJECT_PATTERN_1: TIMESTAMP_1.isoformat()
         }
 
     def test_should_update_datetime_for_object_pattern(self):
         state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=DATETTIME_1
+                last_modified_datetime=TIMESTAMP_1
             )
         })
         state.update_last_modified_datetime(
             object_pattern=OBJECT_PATTERN_1,
-            last_modified_datetime=DATETTIME_2
+            last_modified_datetime=TIMESTAMP_2
         )
         assert state.state_dict[OBJECT_PATTERN_1].last_modified_datetime == (
-            DATETTIME_2
+            TIMESTAMP_2
         )
 
     def test_should_return_initial_state(self):
         state = CsvState.get_initial_state(
             object_patterns=[OBJECT_PATTERN_1],
-            last_modified_datetime=DATETTIME_1
+            last_modified_datetime=TIMESTAMP_1
         )
         assert state.state_dict == {
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=DATETTIME_1
+                last_modified_datetime=TIMESTAMP_1
             )
         }

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -3,29 +3,29 @@ from datetime import timezone
 from data_pipeline.s3_csv_data.s3_csv_state import (
     CsvState,
     ObjectPatternCsvState,
-    convert_datetime_string_to_datetime
+    parse_timestamp
 )
 
 
 DATETTIME_STRING_1 = '2020-01-01 00:00:00'
 DATETTIME_STRING_2 = '2020-01-02 00:00:00'
 
-DATETTIME_1 = convert_datetime_string_to_datetime(DATETTIME_STRING_1)
-DATETTIME_2 = convert_datetime_string_to_datetime(DATETTIME_STRING_2)
+DATETTIME_1 = parse_timestamp(DATETTIME_STRING_1)
+DATETTIME_2 = parse_timestamp(DATETTIME_STRING_2)
 
 OBJECT_PATTERN_1 = 'object_pattern_1*'
 
 
-class TestConvertDatetimeStringToDatetime:
+class TestParseTimestamp:
     def test_should_parse_old_datetime_format(self):
-        timestamp = convert_datetime_string_to_datetime(
+        timestamp = parse_timestamp(
             '2001-02-03 04:05:06'
         )
         assert timestamp.date().isoformat() == '2001-02-03'
         assert timestamp.tzinfo == timezone.utc
 
     def test_should_parse_timestamp(self):
-        timestamp = convert_datetime_string_to_datetime(
+        timestamp = parse_timestamp(
             '2001-02-03T05:06:07+00:00'
         )
         assert timestamp.date().isoformat() == '2001-02-03'

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -37,47 +37,47 @@ class TestCsvState:
         state = CsvState.from_dict({})
         assert not state.state_dict
 
-    def test_should_parse_datetime(self):
+    def test_should_parse_timestamp(self):
         state = CsvState.from_dict({
             OBJECT_PATTERN_1: TIMESTAMP_STRING_1
         })
         assert state.state_dict == {
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         }
 
-    def test_should_serialize_datetime_to_string(self):
+    def test_should_serialize_timestamp_to_string(self):
         state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
         assert state.to_dict() == {
             OBJECT_PATTERN_1: TIMESTAMP_1.isoformat()
         }
 
-    def test_should_update_datetime_for_object_pattern(self):
+    def test_should_update_timestamp_for_object_pattern(self):
         state = CsvState(state_dict={
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         })
-        state.update_last_modified_datetime(
+        state.update_last_modified_timestamp(
             object_pattern=OBJECT_PATTERN_1,
-            last_modified_datetime=TIMESTAMP_2
+            last_modified_timestamp=TIMESTAMP_2
         )
-        assert state.state_dict[OBJECT_PATTERN_1].last_modified_datetime == (
+        assert state.state_dict[OBJECT_PATTERN_1].last_modified_timestamp == (
             TIMESTAMP_2
         )
 
     def test_should_return_initial_state(self):
         state = CsvState.get_initial_state(
             object_patterns=[OBJECT_PATTERN_1],
-            last_modified_datetime=TIMESTAMP_1
+            last_modified_timestamp=TIMESTAMP_1
         )
         assert state.state_dict == {
             OBJECT_PATTERN_1: ObjectPatternCsvState(
-                last_modified_datetime=TIMESTAMP_1
+                last_modified_timestamp=TIMESTAMP_1
             )
         }

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -3,7 +3,8 @@ from datetime import timezone
 from data_pipeline.s3_csv_data.s3_csv_state import (
     CsvState,
     ObjectPatternCsvState,
-    convert_datetime_string_to_datetime
+    convert_datetime_string_to_datetime,
+    convert_datetime_to_string
 )
 
 
@@ -32,6 +33,13 @@ class TestConvertDatetimeStringToDatetime:
         assert timestamp.tzinfo == timezone.utc
 
 
+class TestConvertDatetimeToString:
+    def test_should_format_timestamp_as_isoformat(self):
+        assert convert_datetime_to_string(
+            DATETTIME_1
+        ) == DATETTIME_1.isoformat()
+
+
 class TestCsvState:
     def test_should_load_from_empty_dict(self):
         state = CsvState.from_dict({})
@@ -54,7 +62,7 @@ class TestCsvState:
             )
         })
         assert state.to_dict() == {
-            OBJECT_PATTERN_1: DATETTIME_STRING_1
+            OBJECT_PATTERN_1: DATETTIME_1.isoformat()
         }
 
     def test_should_update_datetime_for_object_pattern(self):

--- a/tests/unit_test/s3_csv_data/s3_csv_state_test.py
+++ b/tests/unit_test/s3_csv_data/s3_csv_state_test.py
@@ -3,8 +3,7 @@ from datetime import timezone
 from data_pipeline.s3_csv_data.s3_csv_state import (
     CsvState,
     ObjectPatternCsvState,
-    convert_datetime_string_to_datetime,
-    convert_datetime_to_string
+    convert_datetime_string_to_datetime
 )
 
 
@@ -31,13 +30,6 @@ class TestConvertDatetimeStringToDatetime:
         )
         assert timestamp.date().isoformat() == '2001-02-03'
         assert timestamp.tzinfo == timezone.utc
-
-
-class TestConvertDatetimeToString:
-    def test_should_format_timestamp_as_isoformat(self):
-        assert convert_datetime_to_string(
-            DATETTIME_1
-        ) == DATETTIME_1.isoformat()
 
 
 class TestCsvState:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1192

This reduces some confusion between when it's a datetime and when a timestamp.
It also addresses: https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1760#issuecomment-3209252312

There is a test that it can load the old date format.
The only difference is that it will explicitly use utc for the old date format whereas before it was using tzlocal (which dependends on the environment).