### PR TITLE
Add k8s-group to dependabot configuration for Kubernetes packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
       patterns:
         - "boto3"
         - "botocore"
+    k8s-group:
+      patterns:
+        - "apache-airflow-providers-cncf-kubernetes"
+        - "kubernetes"


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1189

see: https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1792 and https://github.com/elifesciences/data-hub-core-airflow-dags/pull/1794