### PR TITLE
Fixed DAGs not appearing due to import error in dag-processor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN if [ "${install_dev}" = "y" ]; then \
   fi
 
 ENV PATH /home/airflow/.local/bin:$PATH
+ENV PYTHONPATH /opt/airflow
 
 COPY data_pipeline ./data_pipeline
 COPY dags ./dags


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1339

This bug introduced by #1891 due to not installing project into site-packages anymore.
The DAG validation tests fail because it's not using the same Python path.
We no longer have Airflow end-to-end tests.