### PR TITLE
Add airflow-group to dependabot configuration for Apache Airflow packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
       patterns:
         - "fsspec"
         - "s3fs"
+    airflow-group:
+      patterns:
+        - "apache-airflow"
+        - "apache-airflow-providers-celery"


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/1378 