### PR TITLE
Pin apache-airflow-providers-cncf-kubernetes back to 10.17.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    # 10.17.1 crashes the Airflow scheduler (apache/airflow#67813); fix ships in 10.18.0
+    - dependency-name: "apache-airflow-providers-cncf-kubernetes"
+      versions: [">= 10.17.1, < 10.18.0"]
   groups:
     boto-group:
       patterns:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cattrs==26.1.0
 cloudpickle==3.1.2
 dateparser==1.4.0
 kubernetes
-apache-airflow-providers-cncf-kubernetes==10.17.1
+apache-airflow-providers-cncf-kubernetes==10.17.0
 objsize==0.8.0
 pendulum==3.2.0
 regex==2026.5.9


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1375

10.17.1 introduced a session-sharing bug in KubernetesExecutor (_alive_other_scheduler_job_ids uses create_session() which returns a scoped/thread-local session, closing the scheduler's active session and detaching TaskInstance objects mid-iteration, causing DetachedInstanceError on startup). Tracked at apache/airflow#67813; fix is merged and will ship in 10.18.0.